### PR TITLE
Add Configurable Negative Relevance Support to CDPruner for CLIP-based VLM Models

### DIFF
--- a/src/cpp/src/visual_language/cdpruner/cdpruner.cpp
+++ b/src/cpp/src/visual_language/cdpruner/cdpruner.cpp
@@ -21,6 +21,7 @@ CDPruner::CDPruner(const Config& config)
         std::cout << "CDPruner initialized with configuration:" << std::endl;
         std::cout << "  num_visual_tokens: " << m_config.num_visual_tokens << std::endl;
         std::cout << "  relevance_weight: " << m_config.relevance_weight << std::endl;
+        std::cout << "  use_negative_relevance: " << (m_config.use_negative_relevance ? "true" : "false") << std::endl;
         std::cout << "  enable_pruning: " << (m_config.enable_pruning ? "true" : "false") << std::endl;
         std::cout << "  device: " << m_config.device << std::endl;
     }
@@ -158,6 +159,7 @@ ov::Tensor CDPruner::apply_pruning(const ov::Tensor& visual_features,
     std::cout << "Pruning Configuration:" << std::endl;
     std::cout << "  Target vision tokens (after pruning): " << m_config.num_visual_tokens << std::endl;
     std::cout << "  Relevance weight: " << m_config.relevance_weight << std::endl;
+    std::cout << "  Use negative relevance: " << (m_config.use_negative_relevance ? "true (CLIP/LLaVA mode)" : "false (standard mode)") << std::endl;
     
     // Calculate pruning statistics
     float pruning_ratio = 1.0f - static_cast<float>(m_config.num_visual_tokens) / static_cast<float>(total_tokens);

--- a/src/cpp/src/visual_language/cdpruner/cdpruner.hpp
+++ b/src/cpp/src/visual_language/cdpruner/cdpruner.hpp
@@ -140,9 +140,9 @@ private:
 
     Config m_config;                        ///< Configuration
     RelevanceCalculator m_relevance_calc;   ///< Relevance computation module
-    ConditionalKernelBuilder m_kernel_builder; ///< Kernel matrix construction module
-    FastGreedyDPP m_dpp_selector;          ///< DPP selection module
-    
+    ConditionalKernelBuilder m_kernel_builder;  ///< Kernel matrix construction module (with OpenVINO ops)
+    FastGreedyDPP m_dpp_selector;               ///< DPP selection module
+
     mutable PruningStatistics m_last_statistics; ///< Statistics from last operation
 };
 

--- a/src/cpp/src/visual_language/cdpruner/cdpruner_config.hpp
+++ b/src/cpp/src/visual_language/cdpruner/cdpruner_config.hpp
@@ -31,6 +31,11 @@ struct Config {
     /// @brief Whether to apply negative mean for relevance calculation
     /// This is needed for CLIP-based models (like LLaVA) due to counterintuitive similarity values
     bool use_negative_relevance = false;
+
+    /// @brief Whether to use OpenVINO ops model for computation
+    /// When true, uses integrated OpenVINO ops model for relevance and kernel computation
+    /// When false, uses traditional step-by-step computation pipeline
+    bool use_ops_model = false;
 };
 
 } // namespace ov::genai::cdpruner 

--- a/src/cpp/src/visual_language/cdpruner/cdpruner_config.hpp
+++ b/src/cpp/src/visual_language/cdpruner/cdpruner_config.hpp
@@ -24,9 +24,14 @@ struct Config {
     
     /// @brief Whether to enable debug output
     bool debug_mode = false;
-    
+
     /// @brief Threshold for numerical stability
     float numerical_threshold = 1e-6f;
+
+    /// @brief Whether to apply negative mean for relevance calculation
+    /// This is needed for CLIP-based models (like LLaVA) due to counterintuitive similarity values
+    /// but may not be needed for other visual encoders
+    bool use_negative_relevance = true;
 };
 
 } // namespace ov::genai::cdpruner 

--- a/src/cpp/src/visual_language/cdpruner/cdpruner_config.hpp
+++ b/src/cpp/src/visual_language/cdpruner/cdpruner_config.hpp
@@ -30,8 +30,7 @@ struct Config {
 
     /// @brief Whether to apply negative mean for relevance calculation
     /// This is needed for CLIP-based models (like LLaVA) due to counterintuitive similarity values
-    /// but may not be needed for other visual encoders
-    bool use_negative_relevance = true;
+    bool use_negative_relevance = false;
 };
 
 } // namespace ov::genai::cdpruner 

--- a/src/cpp/src/visual_language/cdpruner/fast_dpp.cpp
+++ b/src/cpp/src/visual_language/cdpruner/fast_dpp.cpp
@@ -162,6 +162,11 @@ void FastGreedyDPP::update_marginal_gains(size_t iteration, size_t selected_idx,
     
     // Update marginal gains for all tokens
     for (size_t j = 0; j < total_tokens; ++j) {
+        // Skip updating if this token is already selected (marked as negative infinity)
+        if (di2s_data[j] == -std::numeric_limits<float>::infinity()) {
+            continue;
+        }
+        
         size_t cis_idx = iteration * total_tokens + j;
         float eis_j = cis_data[cis_idx];
         

--- a/src/cpp/src/visual_language/cdpruner/kernel_builder.hpp
+++ b/src/cpp/src/visual_language/cdpruner/kernel_builder.hpp
@@ -85,12 +85,6 @@ private:
     /// @return Conditional kernel matrix [B, N, N]
     ov::Tensor build_conditional_kernel(const ov::Tensor& similarity_matrix, const ov::Tensor& relevance_scores);
 
-    /// @brief Create L2 normalization subgraph using OpenVINO ops
-    /// @param input Input node to normalize
-    /// @param axis Axis along which to normalize
-    /// @return Normalized node
-    std::shared_ptr<ov::Node> create_l2_normalize_ops(std::shared_ptr<ov::Node> input, int axis);
-
     /// @brief Create min-max normalization subgraph using OpenVINO ops
     /// @param input Input node to normalize
     /// @return Normalized node

--- a/src/cpp/src/visual_language/cdpruner/kernel_builder.hpp
+++ b/src/cpp/src/visual_language/cdpruner/kernel_builder.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "cdpruner_config.hpp"
+#include "openvino/runtime/infer_request.hpp"
 #include "openvino/runtime/tensor.hpp"
 
 namespace ov::genai::cdpruner {
@@ -53,6 +54,10 @@ private:
     /// @return Shared pointer to the OpenVINO model
     std::shared_ptr<ov::Model> create_conditional_kernel_model();
 
+    /// @brief Create OpenVINO ops model for similarity matrix computation
+    /// @return Shared pointer to the OpenVINO model for similarity computation
+    std::shared_ptr<ov::Model> create_similarity_matrix_model();
+
     /// @brief Compute similarity matrix between visual features
     /// @param features Visual feature embeddings [B, N, D]
     /// @return Similarity matrix [B, N, N]
@@ -91,6 +96,11 @@ private:
     std::shared_ptr<ov::Node> create_min_max_normalize_ops(std::shared_ptr<ov::Node> input);
 
     Config m_config;
+
+    // Precompiled infer requests for performance optimization
+    ov::InferRequest m_similarity_infer_request;
+    ov::InferRequest m_conditional_kernel_infer_request;
+    bool m_requests_initialized;
 };
 
-} // namespace ov::genai::cdpruner 
+}  // namespace ov::genai::cdpruner

--- a/src/cpp/src/visual_language/cdpruner/relevance_calculator.hpp
+++ b/src/cpp/src/visual_language/cdpruner/relevance_calculator.hpp
@@ -37,12 +37,13 @@ private:
     /// @param text_embeds Text embeddings [M, C]
     /// @return Similarity matrix [B, N, M]
     ov::Tensor matrix_multiply(const ov::Tensor& visual_embeds, const ov::Tensor& text_embeds);
-    
-    /// @brief Compute negative mean across the last dimension
+
+    /// @brief Compute mean across the last dimension with optional negation
     /// @param relevance_matrix Input relevance matrix [B, N, M]
+    /// @param use_negative Whether to apply negation before computing mean
     /// @return Mean relevance scores [B, N]
-    ov::Tensor compute_negative_mean(const ov::Tensor& relevance_matrix);
-    
+    ov::Tensor compute_mean(const ov::Tensor& relevance_matrix, bool use_negative);
+
     Config m_config;
 };
 

--- a/src/cpp/src/visual_language/llava/classes.cpp
+++ b/src/cpp/src/visual_language/llava/classes.cpp
@@ -80,6 +80,7 @@ VisionEncoderLLaVA::VisionEncoderLLaVA(
         cdpruner_config.relevance_weight = 0.5f;
         cdpruner_config.enable_pruning = true;
         cdpruner_config.device = device;
+        cdpruner_config.use_negative_relevance = true;  // needed for CLIP-based models
         m_cdpruner = std::make_unique<cdpruner::CDPruner>(cdpruner_config);
     } catch (const std::exception& e) {
         // CDPruner initialization failed, disable it for backward compatibility

--- a/src/cpp/src/visual_language/qwen2vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.cpp
@@ -389,6 +389,7 @@ InputsEmbedderQwen2VL::InputsEmbedderQwen2VL(
     cdpruner_config.device = device;          // Use same device as the model
     cdpruner_config.debug_mode = false;       // Disable debug output for production
     cdpruner_config.use_negative_relevance = true;  // needed for CLIP-based models
+    cdpruner_config.use_ops_model = false; // Use OpenVINO ops model for relevance scoring
     m_cdpruner = std::make_unique<ov::genai::cdpruner::CDPruner>(cdpruner_config);
 }
 

--- a/src/cpp/src/visual_language/qwen2vl/classes.cpp
+++ b/src/cpp/src/visual_language/qwen2vl/classes.cpp
@@ -388,6 +388,7 @@ InputsEmbedderQwen2VL::InputsEmbedderQwen2VL(
     cdpruner_config.enable_pruning = true;    // Enable pruning functionality
     cdpruner_config.device = device;          // Use same device as the model
     cdpruner_config.debug_mode = false;       // Disable debug output for production
+    cdpruner_config.use_negative_relevance = true;  // needed for CLIP-based models
     m_cdpruner = std::make_unique<ov::genai::cdpruner::CDPruner>(cdpruner_config);
 }
 


### PR DESCRIPTION
This PR enhances the CDPruner implementation by adding configurable negative relevance calculation support, specifically addressing the unique characteristics of CLIP-based vision-language models like LLaVA and Qwen2-VL.