### PR TITLE
Optimize performance of qwen3.5 series models (0.8b/2b/4b/9b/27b dense and 35b moe)

### DIFF
--- a/src/cpp/src/modeling/layers/rms_norm.cpp
+++ b/src/cpp/src/modeling/layers/rms_norm.cpp
@@ -5,6 +5,7 @@
 
 #include <openvino/core/except.hpp>
 #include <openvino/openvino.hpp>
+#include <ov_ops/rms.hpp>
 
 namespace ov {
 namespace genai {
@@ -41,10 +42,10 @@ const Tensor& RMSNorm::weight() const {
 Tensor RMSNorm::forward(const Tensor& x) const {
     auto orig_dtype = x.dtype();
     auto xf = x.to(ov::element::f32);
-    auto var = xf.pow(2.0f).mean(-1, true);
-    auto norm = xf * (var + eps_).rsqrt();
-    auto w = weight().to(orig_dtype);
-    return norm.to(orig_dtype) * w;
+    auto wf = weight().to(ov::element::f32);
+    auto rms_node = std::make_shared<ov::op::internal::RMS>(
+        xf.output(), wf.output(), static_cast<double>(eps_), orig_dtype);
+    return Tensor(rms_node->output(0), x.context());
 }
 
 std::pair<Tensor, Tensor> RMSNorm::forward(const Tensor& x, const Tensor& residual) const {
@@ -53,11 +54,10 @@ std::pair<Tensor, Tensor> RMSNorm::forward(const Tensor& x, const Tensor& residu
     auto rf = residual.to(ov::element::f32);
     auto sum = xf + rf;
     auto residual_out = sum.to(orig_dtype);
-    auto var = sum.pow(2.0f).mean(-1, true);
-    auto norm = sum * (var + eps_).rsqrt();
-    auto w = weight().to(orig_dtype);
-    auto out = norm.to(orig_dtype) * w;
-    return {out, residual_out};
+    auto wf = weight().to(ov::element::f32);
+    auto rms_node = std::make_shared<ov::op::internal::RMS>(
+        sum.output(), wf.output(), static_cast<double>(eps_), orig_dtype);
+    return {Tensor(rms_node->output(0), x.context()), residual_out};
 }
 
 }  // namespace modeling

--- a/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
+++ b/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
@@ -13,6 +13,7 @@
 #include <openvino/op/tensor_iterator.hpp>
 #include <openvino/op/util/variable.hpp>
 #include <openvino/opsets/opset13.hpp>
+#include <ov_ops/rms.hpp>
 
 #include "modeling/ops/kv_cache.hpp"
 #include "modeling/ops/llm.hpp"
@@ -115,10 +116,11 @@ const Tensor& Qwen3_5RMSNorm::weight() const {
 
 Tensor Qwen3_5RMSNorm::forward(const Tensor& x) const {
     auto x_f32 = x.to(ov::element::f32);
-    auto var = x_f32.pow(2.0f).mean(-1, true);
-    auto norm = x_f32 * (var + eps_).rsqrt();
-    auto scaled = norm * (1.0f + weight().to(ov::element::f32));
-    return scaled.to(x.dtype());
+    // Qwen3.5 uses (1 + weight) as the RMS scale factor.
+    auto gamma = 1.0f + weight().to(ov::element::f32);
+    auto rms_node = std::make_shared<ov::op::internal::RMS>(
+        x_f32.output(), gamma.output(), static_cast<double>(eps_), x.dtype());
+    return Tensor(rms_node->output(0), x.context());
 }
 
 std::pair<Tensor, Tensor> Qwen3_5RMSNorm::forward(const Tensor& x, const Tensor& residual) const {

--- a/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
+++ b/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
@@ -473,7 +473,6 @@ Tensor Qwen3_5GatedDeltaNet::forward(const Tensor& hidden_states,
                                          masked_hidden.dtype(),
                                          state_prefix + ".conv"};
     auto conv_var = std::make_shared<ov::op::util::Variable>(conv_info);
-    auto conv_read = std::make_shared<ov::op::v6::ReadValue>(conv_init.output(), conv_var);
 
     Tensor mixed_after_conv;
     if (use_fused_conv_op()) {
@@ -484,15 +483,13 @@ Tensor Qwen3_5GatedDeltaNet::forward(const Tensor& hidden_states,
             mixed_qkv,                                     // [B, conv_dim, S]
             conv_w_2d,                                      // [conv_dim, kernel_size]
             beam_idx,                                       // [B]
-            Tensor(conv_read->output(0), op_ctx));          // [B, conv_dim, kernel_size]
+            conv_init,                                       // [B, conv_dim, kernel_size]
+            conv_var);
 
         mixed_after_conv = fused_result.first;              // [B, conv_dim, S]
-        auto next_conv_state = fused_result.second;         // [B, conv_dim, kernel_size]
-
-        auto conv_assign = std::make_shared<ov::opset13::Assign>(next_conv_state.output(), conv_var);
-        ctx().register_sink(conv_assign);
     } else {
         // ── Fallback: original decomposed path ──
+        auto conv_read = std::make_shared<ov::op::v6::ReadValue>(conv_init.output(), conv_var);
         auto conv_cached = ops::gather(Tensor(conv_read->output(0), op_ctx), beam_idx, 0);
 
         Tensor next_conv_state;

--- a/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
+++ b/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
@@ -197,8 +197,7 @@ Tensor Qwen3_5Attention::forward(const Tensor& hidden_states,
                                    const Tensor& beam_idx,
                                    const Tensor& rope_cos,
                                    const Tensor& rope_sin,
-                                   const Tensor* attention_mask,
-                                   const Tensor* precomputed_sdpa_mask) const {
+                                   const Tensor* attention_mask) const {
     auto* policy = &ctx().op_policy();
     auto* op_ctx = hidden_states.context();
 
@@ -214,26 +213,18 @@ Tensor Qwen3_5Attention::forward(const Tensor& hidden_states,
     auto v_heads = v_states.permute({0, 2, 1, 3});
 
     if (rotary_dim_ > 0) {
-        // Directly rotate full heads when internal RoPE is enabled.
-        // This avoids slice/concat around partial rotary dimensions.
-        const bool direct_full_head_rope = (!policy || policy->use_internal_rope || rotary_dim_ == head_dim_);
-        if (direct_full_head_rope) {
-            q_heads = ops::llm::apply_rope(q_heads, rope_cos, rope_sin, rotary_dim_, policy);
-            k_heads = ops::llm::apply_rope(k_heads, rope_cos, rope_sin, rotary_dim_, policy);
+        auto q_rot = ops::slice(q_heads, 0, rotary_dim_, 1, 3);
+        auto k_rot = ops::slice(k_heads, 0, rotary_dim_, 1, 3);
+        auto q_rotated = ops::llm::apply_rope(q_rot, rope_cos, rope_sin, rotary_dim_, policy);
+        auto k_rotated = ops::llm::apply_rope(k_rot, rope_cos, rope_sin, rotary_dim_, policy);
+        if (rotary_dim_ < head_dim_) {
+            auto q_pass = ops::slice(q_heads, rotary_dim_, head_dim_, 1, 3);
+            auto k_pass = ops::slice(k_heads, rotary_dim_, head_dim_, 1, 3);
+            q_heads = ops::concat({q_rotated, q_pass}, 3);
+            k_heads = ops::concat({k_rotated, k_pass}, 3);
         } else {
-            auto q_rot = ops::slice(q_heads, 0, rotary_dim_, 1, 3);
-            auto k_rot = ops::slice(k_heads, 0, rotary_dim_, 1, 3);
-            auto q_rotated = ops::llm::apply_rope(q_rot, rope_cos, rope_sin, rotary_dim_, policy);
-            auto k_rotated = ops::llm::apply_rope(k_rot, rope_cos, rope_sin, rotary_dim_, policy);
-            if (rotary_dim_ < head_dim_) {
-                auto q_pass = ops::slice(q_heads, rotary_dim_, head_dim_, 1, 3);
-                auto k_pass = ops::slice(k_heads, rotary_dim_, head_dim_, 1, 3);
-                q_heads = ops::concat({q_rotated, q_pass}, 3);
-                k_heads = ops::concat({k_rotated, k_pass}, 3);
-            } else {
-                q_heads = q_rotated;
-                k_heads = k_rotated;
-            }
+            q_heads = q_rotated;
+            k_heads = k_rotated;
         }
     }
 
@@ -242,16 +233,10 @@ Tensor Qwen3_5Attention::forward(const Tensor& hidden_states,
     auto k_expanded = ops::llm::repeat_kv(cached.first, num_heads_, num_kv_heads_, head_dim_);
     auto v_expanded = ops::llm::repeat_kv(cached.second, num_heads_, num_kv_heads_, head_dim_);
 
-    const Tensor* sdpa_mask = precomputed_sdpa_mask;
-    std::optional<Tensor> local_mask;
-    if (!sdpa_mask) {
-        // Build mask from non-repeated K so repeat_kv output can stay single-consumer for SDPA fusion.
-        local_mask = attention_mask ? ops::llm::build_kv_causal_mask_with_attention(q_heads, cached.first, *attention_mask)
-                                    : ops::llm::build_kv_causal_mask(q_heads, cached.first);
-        sdpa_mask = &(*local_mask);
-    }
-
-    auto attn = ops::llm::sdpa(q_heads, k_expanded, v_expanded, scaling_, 3, sdpa_mask, false, policy);
+    Tensor mask = attention_mask
+                      ? ops::llm::build_kv_causal_mask_with_attention(q_heads, cached.first, *attention_mask)
+                      : ops::llm::build_kv_causal_mask(q_heads, cached.first);
+    auto attn = ops::llm::sdpa(q_heads, k_expanded, v_expanded, scaling_, 3, &mask, false, policy);
 
     const int64_t attn_hidden = static_cast<int64_t>(num_heads_) * static_cast<int64_t>(head_dim_);
     auto merged = attn.permute({0, 2, 1, 3}).reshape({0, 0, attn_hidden});
@@ -668,8 +653,7 @@ std::pair<Tensor, Tensor> Qwen3_5DecoderLayer::forward(const Tensor& hidden_stat
                                                          const Tensor* full_attention_mask,
                                                          const Tensor* linear_attention_mask,
                                                          const Tensor* cache_position,
-                                                         const std::optional<Tensor>& residual,
-                                                         const Tensor* precomputed_full_attn_sdpa_mask) const {
+                                                         const std::optional<Tensor>& residual) const {
     Tensor normed;
     Tensor next_residual;
     if (residual) {
@@ -683,12 +667,7 @@ std::pair<Tensor, Tensor> Qwen3_5DecoderLayer::forward(const Tensor& hidden_stat
 
     Tensor mixed;
     if (layer_type_ == "full_attention") {
-        mixed = self_attn_->forward(normed,
-                                    beam_idx,
-                                    rope_cos,
-                                    rope_sin,
-                                    full_attention_mask,
-                                    precomputed_full_attn_sdpa_mask);
+        mixed = self_attn_->forward(normed, beam_idx, rope_cos, rope_sin, full_attention_mask);
     } else {
         mixed = linear_attn_->forward(normed, beam_idx, linear_attention_mask, cache_position);
     }
@@ -824,15 +803,12 @@ Tensor Qwen3_5Model::forward_impl(const Tensor* input_ids,
         hidden_states = embedding_injector_.forward(hidden_states, *visual_embeds, *visual_pos_mask);
     }
     auto cos_sin = build_mrope_cos_sin(position_ids);
-    const Tensor& seq_source = inputs_embeds ? *inputs_embeds : *input_ids;
-    auto* op_ctx = seq_source.context();
-    auto q_len_1d = Tensor(shape::dim(seq_source, 1), op_ctx);
-    auto shared_full_attn_sdpa_mask =
-        ops::llm::build_kv_causal_mask_with_attention_from_q_len(q_len_1d, full_attention_mask);
 
     std::optional<Tensor> linear_mask_view;
     const Tensor* linear_mask = nullptr;
     if (linear_attention_mask) {
+        const Tensor& seq_source = inputs_embeds ? *inputs_embeds : *input_ids;
+        auto* op_ctx = seq_source.context();
         auto q_len = shape::dim(seq_source, 1);
         auto mask_len = shape::dim(*linear_attention_mask, 1);
         auto start = std::make_shared<ov::op::v1::Subtract>(mask_len, q_len);
@@ -855,8 +831,7 @@ Tensor Qwen3_5Model::forward_impl(const Tensor* input_ids,
                                  &full_attention_mask,
                                  linear_mask,
                                  cache_position,
-                                 residual,
-                                 &shared_full_attn_sdpa_mask);
+                                 residual);
         hidden_states = out.first;
         residual = out.second;
     }

--- a/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
+++ b/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
@@ -197,7 +197,8 @@ Tensor Qwen3_5Attention::forward(const Tensor& hidden_states,
                                    const Tensor& beam_idx,
                                    const Tensor& rope_cos,
                                    const Tensor& rope_sin,
-                                   const Tensor* attention_mask) const {
+                                   const Tensor* attention_mask,
+                                   const Tensor* precomputed_sdpa_mask) const {
     auto* policy = &ctx().op_policy();
     auto* op_ctx = hidden_states.context();
 
@@ -213,18 +214,26 @@ Tensor Qwen3_5Attention::forward(const Tensor& hidden_states,
     auto v_heads = v_states.permute({0, 2, 1, 3});
 
     if (rotary_dim_ > 0) {
-        auto q_rot = ops::slice(q_heads, 0, rotary_dim_, 1, 3);
-        auto k_rot = ops::slice(k_heads, 0, rotary_dim_, 1, 3);
-        auto q_rotated = ops::llm::apply_rope(q_rot, rope_cos, rope_sin, rotary_dim_, policy);
-        auto k_rotated = ops::llm::apply_rope(k_rot, rope_cos, rope_sin, rotary_dim_, policy);
-        if (rotary_dim_ < head_dim_) {
-            auto q_pass = ops::slice(q_heads, rotary_dim_, head_dim_, 1, 3);
-            auto k_pass = ops::slice(k_heads, rotary_dim_, head_dim_, 1, 3);
-            q_heads = ops::concat({q_rotated, q_pass}, 3);
-            k_heads = ops::concat({k_rotated, k_pass}, 3);
+        // Directly rotate full heads when internal RoPE is enabled.
+        // This avoids slice/concat around partial rotary dimensions.
+        const bool direct_full_head_rope = (!policy || policy->use_internal_rope || rotary_dim_ == head_dim_);
+        if (direct_full_head_rope) {
+            q_heads = ops::llm::apply_rope(q_heads, rope_cos, rope_sin, rotary_dim_, policy);
+            k_heads = ops::llm::apply_rope(k_heads, rope_cos, rope_sin, rotary_dim_, policy);
         } else {
-            q_heads = q_rotated;
-            k_heads = k_rotated;
+            auto q_rot = ops::slice(q_heads, 0, rotary_dim_, 1, 3);
+            auto k_rot = ops::slice(k_heads, 0, rotary_dim_, 1, 3);
+            auto q_rotated = ops::llm::apply_rope(q_rot, rope_cos, rope_sin, rotary_dim_, policy);
+            auto k_rotated = ops::llm::apply_rope(k_rot, rope_cos, rope_sin, rotary_dim_, policy);
+            if (rotary_dim_ < head_dim_) {
+                auto q_pass = ops::slice(q_heads, rotary_dim_, head_dim_, 1, 3);
+                auto k_pass = ops::slice(k_heads, rotary_dim_, head_dim_, 1, 3);
+                q_heads = ops::concat({q_rotated, q_pass}, 3);
+                k_heads = ops::concat({k_rotated, k_pass}, 3);
+            } else {
+                q_heads = q_rotated;
+                k_heads = k_rotated;
+            }
         }
     }
 
@@ -233,10 +242,16 @@ Tensor Qwen3_5Attention::forward(const Tensor& hidden_states,
     auto k_expanded = ops::llm::repeat_kv(cached.first, num_heads_, num_kv_heads_, head_dim_);
     auto v_expanded = ops::llm::repeat_kv(cached.second, num_heads_, num_kv_heads_, head_dim_);
 
-    Tensor mask = attention_mask
-                      ? ops::llm::build_kv_causal_mask_with_attention(q_heads, k_expanded, *attention_mask)
-                      : ops::llm::build_kv_causal_mask(q_heads, k_expanded);
-    auto attn = ops::llm::sdpa(q_heads, k_expanded, v_expanded, scaling_, 3, &mask, false, policy);
+    const Tensor* sdpa_mask = precomputed_sdpa_mask;
+    std::optional<Tensor> local_mask;
+    if (!sdpa_mask) {
+        // Build mask from non-repeated K so repeat_kv output can stay single-consumer for SDPA fusion.
+        local_mask = attention_mask ? ops::llm::build_kv_causal_mask_with_attention(q_heads, cached.first, *attention_mask)
+                                    : ops::llm::build_kv_causal_mask(q_heads, cached.first);
+        sdpa_mask = &(*local_mask);
+    }
+
+    auto attn = ops::llm::sdpa(q_heads, k_expanded, v_expanded, scaling_, 3, sdpa_mask, false, policy);
 
     const int64_t attn_hidden = static_cast<int64_t>(num_heads_) * static_cast<int64_t>(head_dim_);
     auto merged = attn.permute({0, 2, 1, 3}).reshape({0, 0, attn_hidden});
@@ -653,7 +668,8 @@ std::pair<Tensor, Tensor> Qwen3_5DecoderLayer::forward(const Tensor& hidden_stat
                                                          const Tensor* full_attention_mask,
                                                          const Tensor* linear_attention_mask,
                                                          const Tensor* cache_position,
-                                                         const std::optional<Tensor>& residual) const {
+                                                         const std::optional<Tensor>& residual,
+                                                         const Tensor* precomputed_full_attn_sdpa_mask) const {
     Tensor normed;
     Tensor next_residual;
     if (residual) {
@@ -667,7 +683,12 @@ std::pair<Tensor, Tensor> Qwen3_5DecoderLayer::forward(const Tensor& hidden_stat
 
     Tensor mixed;
     if (layer_type_ == "full_attention") {
-        mixed = self_attn_->forward(normed, beam_idx, rope_cos, rope_sin, full_attention_mask);
+        mixed = self_attn_->forward(normed,
+                                    beam_idx,
+                                    rope_cos,
+                                    rope_sin,
+                                    full_attention_mask,
+                                    precomputed_full_attn_sdpa_mask);
     } else {
         mixed = linear_attn_->forward(normed, beam_idx, linear_attention_mask, cache_position);
     }
@@ -803,12 +824,15 @@ Tensor Qwen3_5Model::forward_impl(const Tensor* input_ids,
         hidden_states = embedding_injector_.forward(hidden_states, *visual_embeds, *visual_pos_mask);
     }
     auto cos_sin = build_mrope_cos_sin(position_ids);
+    const Tensor& seq_source = inputs_embeds ? *inputs_embeds : *input_ids;
+    auto* op_ctx = seq_source.context();
+    auto q_len_1d = Tensor(shape::dim(seq_source, 1), op_ctx);
+    auto shared_full_attn_sdpa_mask =
+        ops::llm::build_kv_causal_mask_with_attention_from_q_len(q_len_1d, full_attention_mask);
 
     std::optional<Tensor> linear_mask_view;
     const Tensor* linear_mask = nullptr;
     if (linear_attention_mask) {
-        const Tensor& seq_source = inputs_embeds ? *inputs_embeds : *input_ids;
-        auto* op_ctx = seq_source.context();
         auto q_len = shape::dim(seq_source, 1);
         auto mask_len = shape::dim(*linear_attention_mask, 1);
         auto start = std::make_shared<ov::op::v1::Subtract>(mask_len, q_len);
@@ -831,7 +855,8 @@ Tensor Qwen3_5Model::forward_impl(const Tensor* input_ids,
                                  &full_attention_mask,
                                  linear_mask,
                                  cache_position,
-                                 residual);
+                                 residual,
+                                 &shared_full_attn_sdpa_mask);
         hidden_states = out.first;
         residual = out.second;
     }

--- a/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
+++ b/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
@@ -214,19 +214,8 @@ Tensor Qwen3_5Attention::forward(const Tensor& hidden_states,
     auto v_heads = v_states.permute({0, 2, 1, 3});
 
     if (rotary_dim_ > 0) {
-        auto q_rot = ops::slice(q_heads, 0, rotary_dim_, 1, 3);
-        auto k_rot = ops::slice(k_heads, 0, rotary_dim_, 1, 3);
-        auto q_rotated = ops::llm::apply_rope(q_rot, rope_cos, rope_sin, rotary_dim_, policy);
-        auto k_rotated = ops::llm::apply_rope(k_rot, rope_cos, rope_sin, rotary_dim_, policy);
-        if (rotary_dim_ < head_dim_) {
-            auto q_pass = ops::slice(q_heads, rotary_dim_, head_dim_, 1, 3);
-            auto k_pass = ops::slice(k_heads, rotary_dim_, head_dim_, 1, 3);
-            q_heads = ops::concat({q_rotated, q_pass}, 3);
-            k_heads = ops::concat({k_rotated, k_pass}, 3);
-        } else {
-            q_heads = q_rotated;
-            k_heads = k_rotated;
-        }
+        q_heads = ops::llm::apply_rope(q_heads, rope_cos, rope_sin, rotary_dim_, policy, head_dim_);
+        k_heads = ops::llm::apply_rope(k_heads, rope_cos, rope_sin, rotary_dim_, policy, head_dim_);
     }
 
     const std::string cache_prefix = full_path().empty() ? name() : full_path();

--- a/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
+++ b/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
@@ -197,7 +197,8 @@ Tensor Qwen3_5Attention::forward(const Tensor& hidden_states,
                                    const Tensor& beam_idx,
                                    const Tensor& rope_cos,
                                    const Tensor& rope_sin,
-                                   const Tensor* attention_mask) const {
+                                   const Tensor* attention_mask,
+                                   const Tensor* precomputed_sdpa_mask) const {
     auto* policy = &ctx().op_policy();
     auto* op_ctx = hidden_states.context();
 
@@ -233,10 +234,14 @@ Tensor Qwen3_5Attention::forward(const Tensor& hidden_states,
     auto k_expanded = ops::llm::repeat_kv(cached.first, num_heads_, num_kv_heads_, head_dim_);
     auto v_expanded = ops::llm::repeat_kv(cached.second, num_heads_, num_kv_heads_, head_dim_);
 
-    Tensor mask = attention_mask
-                      ? ops::llm::build_kv_causal_mask_with_attention(q_heads, cached.first, *attention_mask)
-                      : ops::llm::build_kv_causal_mask(q_heads, cached.first);
-    auto attn = ops::llm::sdpa(q_heads, k_expanded, v_expanded, scaling_, 3, &mask, false, policy);
+    const Tensor* sdpa_mask = precomputed_sdpa_mask;
+    std::optional<Tensor> local_mask;
+    if (!sdpa_mask) {
+        local_mask = attention_mask ? ops::llm::build_kv_causal_mask_with_attention(q_heads, cached.first, *attention_mask)
+                                    : ops::llm::build_kv_causal_mask(q_heads, cached.first);
+        sdpa_mask = &(*local_mask);
+    }
+    auto attn = ops::llm::sdpa(q_heads, k_expanded, v_expanded, scaling_, 3, sdpa_mask, false, policy);
 
     const int64_t attn_hidden = static_cast<int64_t>(num_heads_) * static_cast<int64_t>(head_dim_);
     auto merged = attn.permute({0, 2, 1, 3}).reshape({0, 0, attn_hidden});
@@ -653,7 +658,8 @@ std::pair<Tensor, Tensor> Qwen3_5DecoderLayer::forward(const Tensor& hidden_stat
                                                          const Tensor* full_attention_mask,
                                                          const Tensor* linear_attention_mask,
                                                          const Tensor* cache_position,
-                                                         const std::optional<Tensor>& residual) const {
+                                                         const std::optional<Tensor>& residual,
+                                                         const Tensor* precomputed_full_attn_sdpa_mask) const {
     Tensor normed;
     Tensor next_residual;
     if (residual) {
@@ -667,7 +673,12 @@ std::pair<Tensor, Tensor> Qwen3_5DecoderLayer::forward(const Tensor& hidden_stat
 
     Tensor mixed;
     if (layer_type_ == "full_attention") {
-        mixed = self_attn_->forward(normed, beam_idx, rope_cos, rope_sin, full_attention_mask);
+        mixed = self_attn_->forward(normed,
+                                    beam_idx,
+                                    rope_cos,
+                                    rope_sin,
+                                    full_attention_mask,
+                                    precomputed_full_attn_sdpa_mask);
     } else {
         mixed = linear_attn_->forward(normed, beam_idx, linear_attention_mask, cache_position);
     }
@@ -803,12 +814,15 @@ Tensor Qwen3_5Model::forward_impl(const Tensor* input_ids,
         hidden_states = embedding_injector_.forward(hidden_states, *visual_embeds, *visual_pos_mask);
     }
     auto cos_sin = build_mrope_cos_sin(position_ids);
+    const Tensor& seq_source = inputs_embeds ? *inputs_embeds : *input_ids;
+    auto* op_ctx = seq_source.context();
+    auto q_len_1d = Tensor(shape::dim(seq_source, 1), op_ctx);
+    auto shared_full_attn_sdpa_mask =
+        ops::llm::build_kv_causal_mask_with_attention_from_q_len(q_len_1d, full_attention_mask);
 
     std::optional<Tensor> linear_mask_view;
     const Tensor* linear_mask = nullptr;
     if (linear_attention_mask) {
-        const Tensor& seq_source = inputs_embeds ? *inputs_embeds : *input_ids;
-        auto* op_ctx = seq_source.context();
         auto q_len = shape::dim(seq_source, 1);
         auto mask_len = shape::dim(*linear_attention_mask, 1);
         auto start = std::make_shared<ov::op::v1::Subtract>(mask_len, q_len);
@@ -831,7 +845,8 @@ Tensor Qwen3_5Model::forward_impl(const Tensor* input_ids,
                                  &full_attention_mask,
                                  linear_mask,
                                  cache_position,
-                                 residual);
+                                 residual,
+                                 &shared_full_attn_sdpa_mask);
         hidden_states = out.first;
         residual = out.second;
     }

--- a/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
+++ b/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
@@ -65,6 +65,13 @@ bool use_linear_attention_op() {
     return std::string(raw) != "0";
 }
 
+bool use_fused_conv_op() {
+    const char* raw = std::getenv("OV_GENAI_USE_FUSED_CONV_OP");
+    if (!raw || raw[0] == '\0')
+        return true;  // enabled by default
+    return std::string(raw) != "0";
+}
+
 ov::genai::modeling::models::Qwen3_5TextModelConfig apply_qwen3_5_layer_limit(
     const ov::genai::modeling::models::Qwen3_5TextModelConfig& input_cfg) {
     auto cfg = input_cfg;
@@ -467,12 +474,32 @@ Tensor Qwen3_5GatedDeltaNet::forward(const Tensor& hidden_states,
                                          state_prefix + ".conv"};
     auto conv_var = std::make_shared<ov::op::util::Variable>(conv_info);
     auto conv_read = std::make_shared<ov::op::v6::ReadValue>(conv_init.output(), conv_var);
-    auto conv_cached = ops::gather(Tensor(conv_read->output(0), op_ctx), beam_idx, 0);
 
-    Tensor next_conv_state;
-    auto mixed_after_conv = apply_depthwise_causal_conv(mixed_qkv, conv_cached, &next_conv_state);
-    auto conv_assign = std::make_shared<ov::opset13::Assign>(next_conv_state.output(), conv_var);
-    ctx().register_sink(conv_assign);
+    Tensor mixed_after_conv;
+    if (use_fused_conv_op()) {
+        // ── FusedConv op path: fuses Gather + Concat + GroupConv + SiLU + Slice ──
+        auto conv_w_2d = conv1d_weight().reshape({conv_dim_, conv_kernel_size_}, false);
+
+        auto fused_result = ops::fused_conv(
+            mixed_qkv,                                     // [B, conv_dim, S]
+            conv_w_2d,                                      // [conv_dim, kernel_size]
+            beam_idx,                                       // [B]
+            Tensor(conv_read->output(0), op_ctx));          // [B, conv_dim, kernel_size]
+
+        mixed_after_conv = fused_result.first;              // [B, conv_dim, S]
+        auto next_conv_state = fused_result.second;         // [B, conv_dim, kernel_size]
+
+        auto conv_assign = std::make_shared<ov::opset13::Assign>(next_conv_state.output(), conv_var);
+        ctx().register_sink(conv_assign);
+    } else {
+        // ── Fallback: original decomposed path ──
+        auto conv_cached = ops::gather(Tensor(conv_read->output(0), op_ctx), beam_idx, 0);
+
+        Tensor next_conv_state;
+        mixed_after_conv = apply_depthwise_causal_conv(mixed_qkv, conv_cached, &next_conv_state);
+        auto conv_assign = std::make_shared<ov::opset13::Assign>(next_conv_state.output(), conv_var);
+        ctx().register_sink(conv_assign);
+    }
 
     auto mixed_bt = mixed_after_conv.permute({0, 2, 1});
     auto q_conv = ops::slice(mixed_bt, 0, key_dim_, 1, 2);

--- a/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.hpp
+++ b/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.hpp
@@ -109,8 +109,7 @@ public:
                    const Tensor& beam_idx,
                    const Tensor& rope_cos,
                    const Tensor& rope_sin,
-                   const Tensor* attention_mask,
-                   const Tensor* precomputed_sdpa_mask = nullptr) const;
+                   const Tensor* attention_mask) const;
 
 private:
     const Tensor& q_proj_weight() const;
@@ -218,8 +217,7 @@ public:
                                       const Tensor* full_attention_mask,
                                       const Tensor* linear_attention_mask,
                                       const Tensor* cache_position,
-                                      const std::optional<Tensor>& residual,
-                                      const Tensor* precomputed_full_attn_sdpa_mask = nullptr) const;
+                                      const std::optional<Tensor>& residual) const;
 
 private:
     std::string layer_type_;

--- a/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.hpp
+++ b/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.hpp
@@ -109,7 +109,8 @@ public:
                    const Tensor& beam_idx,
                    const Tensor& rope_cos,
                    const Tensor& rope_sin,
-                   const Tensor* attention_mask) const;
+                   const Tensor* attention_mask,
+                   const Tensor* precomputed_sdpa_mask = nullptr) const;
 
 private:
     const Tensor& q_proj_weight() const;
@@ -217,7 +218,8 @@ public:
                                       const Tensor* full_attention_mask,
                                       const Tensor* linear_attention_mask,
                                       const Tensor* cache_position,
-                                      const std::optional<Tensor>& residual) const;
+                                      const std::optional<Tensor>& residual,
+                                      const Tensor* precomputed_full_attn_sdpa_mask = nullptr) const;
 
 private:
     std::string layer_type_;

--- a/src/cpp/src/modeling/ops/llm.cpp
+++ b/src/cpp/src/modeling/ops/llm.cpp
@@ -174,7 +174,9 @@ Tensor repeat_kv(const Tensor& x, int32_t num_heads, int32_t num_kv_heads, int32
     auto hdim = const_vec(ctx, std::vector<int64_t>{static_cast<int64_t>(head_dim)});
 
     auto target = shape::make({batch, kv_heads, rep, seq, hdim});
-    auto broadcast = shape::broadcast_to(unsq, target);
+    // Use BIDIRECTIONAL broadcast to match GPU's Unsqueeze+Broadcast+Reshape+SDPA fusion pattern.
+    auto broadcast = Tensor(
+        std::make_shared<ov::op::v3::Broadcast>(unsq.output(), target, ov::op::BroadcastType::BIDIRECTIONAL), ctx);
 
     auto heads = const_vec(ctx, std::vector<int64_t>{static_cast<int64_t>(num_heads)});
     auto reshape_shape = shape::make({batch, heads, seq, hdim});

--- a/src/cpp/src/modeling/ops/llm.cpp
+++ b/src/cpp/src/modeling/ops/llm.cpp
@@ -110,11 +110,12 @@ Tensor apply_rope(const Tensor& x,
         config.head_cnt = static_cast<size_t>(x_ps[1].get_length());
     }
 
-    // Unsqueeze to 4D: [batch, 1, seq, half_rotary_ndims] to use GPU's 4D RoPE path
-    // which is more thoroughly tested than the 3D path that has indexing bugs
-    auto dtype = x.dtype();
-    auto cos_4d = cos.to(dtype).unsqueeze(1);  // [batch, 1, seq, half_rotary_ndims]
-    auto sin_4d = sin.to(dtype).unsqueeze(1);  // [batch, 1, seq, half_rotary_ndims]
+    // Keep cos/sin tables in their original precision.
+    // Internal RoPE kernels already support mixed x/cos/sin precision, and
+    // downcasting trig tables to x.dtype regresses rotation accuracy on GPU.
+    // CPU RoPE also reads cos/sin buffers as float tables.
+    auto cos_4d = cos.unsqueeze(1);  // [batch, 1, seq, half_rotary_ndims]
+    auto sin_4d = sin.unsqueeze(1);  // [batch, 1, seq, half_rotary_ndims]
 
     auto rope_node = std::make_shared<op::internal::RoPE>(
         ov::OutputVector{x.output(), cos_4d.output(), sin_4d.output()},

--- a/src/cpp/src/modeling/ops/llm.cpp
+++ b/src/cpp/src/modeling/ops/llm.cpp
@@ -46,30 +46,45 @@ std::pair<Tensor, Tensor> rope_cos_sin(const Tensor& positions,
 Tensor apply_rope(const Tensor& x,
                   const Tensor& cos,
                   const Tensor& sin,
-                  int32_t head_dim,
-                  const OpPolicy* policy) {
-    if (head_dim % 2 != 0) {
-        OPENVINO_THROW("apply_rope expects even head_dim");
+                  int32_t rotary_ndims,
+                  const OpPolicy* policy,
+                  int32_t head_size) {
+    if (rotary_ndims % 2 != 0) {
+        OPENVINO_THROW("apply_rope expects even rotary_ndims");
     }
-    (void)policy;
-    // Align rotary factors with activation dtype to avoid mixed-type multiplies.
-    auto dtype = x.dtype();
-    auto cos_unsq = cos.to(dtype).unsqueeze(1);
-    auto sin_unsq = sin.to(dtype).unsqueeze(1);
-    int64_t half_dim = head_dim / 2;
+    if (head_size < 0) {
+        head_size = rotary_ndims;
+    }
+    if (head_size < rotary_ndims) {
+        OPENVINO_THROW("apply_rope expects head_size >= rotary_ndims");
+    }
+    const auto x_ps = x.output().get_partial_shape();
+    const auto x_rank = x_ps.rank();
+    if (x_rank.is_static() && x_rank.get_length() > 0) {
+        const auto& last_dim = x_ps[x_rank.get_length() - 1];
+        if (last_dim.is_static() && last_dim.get_length() != head_size) {
+            OPENVINO_THROW("apply_rope head_size mismatch: expected last dim ", head_size, ", got ", last_dim.get_length());
+        }
+    }
+    const int32_t half_rotary_ndims = rotary_ndims / 2;
 
     const bool use_internal = policy ? policy->use_internal_rope : true;
     if (!use_internal) {
-        const int32_t half_dim = head_dim / 2;
         auto cos_cast = cos.to(x.dtype()).unsqueeze(1);  // [B, 1, S, half]
         auto sin_cast = sin.to(x.dtype()).unsqueeze(1);  // [B, 1, S, half]
 
-        auto x1 = slice(x, 0, half_dim, 1, 3);
-        auto x2 = slice(x, half_dim, head_dim, 1, 3);
+        auto x1 = slice(x, 0, half_rotary_ndims, 1, 3);
+        auto x2 = slice(x, half_rotary_ndims, rotary_ndims, 1, 3);
 
         auto out1 = x1 * cos_cast - x2 * sin_cast;
         auto out2 = x1 * sin_cast + x2 * cos_cast;
-        return concat({out1, out2}, 3);
+        auto rotated = concat({out1, out2}, 3);
+        if (head_size == rotary_ndims) {
+            return rotated;
+        }
+
+        auto tail = slice(x, rotary_ndims, head_size, 1, 3);
+        return concat({rotated, tail}, 3);
     }
 
     // Use internal RoPE op directly for optimal GPU performance.
@@ -77,28 +92,29 @@ Tensor apply_rope(const Tensor& x,
     //
     // Input shapes:
     //   x: [batch, heads, seq, head_dim]
-    //   cos/sin: [batch, seq, half_dim] where half_dim = head_dim / 2
+    //   cos/sin: [batch, seq, half_rotary_ndims]
     //
-    // RoPE op expects cos/sin with shape [batch, seq, rotary_ndims] and will
-    // handle the rotation internally.
+    // Keep x at full head_size and pass half-width cos/sin tables directly.
+    // The RoPE kernel can then rotate only rotary_ndims and preserve the tail
+    // without materializing slice/concat scaffolding in the graph.
 
     op::internal::RoPE::Config config;
-    config.rotary_ndims = static_cast<size_t>(head_dim);
+    config.rotary_ndims = static_cast<size_t>(rotary_ndims);
+    config.cos_sin_ndims = static_cast<size_t>(half_rotary_ndims);
     config.is_interleaved = false;
     config.input_trans0213 = false;
     config.output_trans0213 = false;
+    config.head_size = static_cast<size_t>(head_size);
 
-    // Expand cos/sin from half_dim to head_dim by concatenating with themselves
-    auto cos_full = concat({cos, cos}, 2);  // [batch, seq, head_dim]
-    auto sin_full = concat({sin, sin}, 2);  // [batch, seq, head_dim]
+    if (x_ps.rank().is_static() && x_ps.rank().get_length() == 4 && x_ps[1].is_static()) {
+        config.head_cnt = static_cast<size_t>(x_ps[1].get_length());
+    }
 
-    // Unsqueeze to 4D: [batch, 1, seq, head_dim] to use GPU's 4D RoPE path
+    // Unsqueeze to 4D: [batch, 1, seq, half_rotary_ndims] to use GPU's 4D RoPE path
     // which is more thoroughly tested than the 3D path that has indexing bugs
-    auto cos_4d = cos_full.unsqueeze(1);  // [batch, 1, seq, head_dim]
-    auto sin_4d = sin_full.unsqueeze(1);  // [batch, 1, seq, head_dim]
-
-    // Since we expanded cos/sin to full head_dim, set cos_sin_ndims accordingly
-    config.cos_sin_ndims = static_cast<size_t>(head_dim);
+    auto dtype = x.dtype();
+    auto cos_4d = cos.to(dtype).unsqueeze(1);  // [batch, 1, seq, half_rotary_ndims]
+    auto sin_4d = sin.to(dtype).unsqueeze(1);  // [batch, 1, seq, half_rotary_ndims]
 
     auto rope_node = std::make_shared<op::internal::RoPE>(
         ov::OutputVector{x.output(), cos_4d.output(), sin_4d.output()},
@@ -112,7 +128,6 @@ Tensor apply_rope_interleave(const Tensor& x,
                              const Tensor& sin,
                              int32_t head_dim,
                              const OpPolicy* policy) {
-    (void)policy;
     const int32_t half_dim = head_dim / 2;
     auto interleaved = x.reshape({0, 0, 0, half_dim, 2})
                            .permute({0, 1, 2, 4, 3})

--- a/src/cpp/src/modeling/ops/llm.cpp
+++ b/src/cpp/src/modeling/ops/llm.cpp
@@ -201,6 +201,69 @@ Tensor causal_mask(const Tensor& scores) {
     return shape::broadcast_to(mask4d, scores_shape);
 }
 
+namespace {
+
+Tensor build_kv_causal_mask_impl(ov::genai::modeling::OpContext* ctx,
+                                 const ov::Output<ov::Node>& batch,
+                                 const Tensor& q_len_1d,
+                                 const Tensor& kv_len_1d,
+                                 const Tensor* attention_mask) {
+    // Squeeze [1] length tensors to scalars for Range ops.
+    auto q_len_scalar = q_len_1d.squeeze(0);
+    auto kv_len_scalar = kv_len_1d.squeeze(0);
+
+    // cache_len = kv_len - q_len.
+    auto cache_len_scalar = Tensor(
+        std::make_shared<ov::opset13::Subtract>(kv_len_scalar.output(), q_len_scalar.output())->output(0), ctx);
+
+    auto cache_len_i32 = Tensor(
+        std::make_shared<ov::op::v0::Convert>(cache_len_scalar.output(), ov::element::i32)->output(0), ctx);
+    auto q_len_i32 = Tensor(
+        std::make_shared<ov::op::v0::Convert>(q_len_scalar.output(), ov::element::i32)->output(0), ctx);
+    auto kv_len_i32 = Tensor(
+        std::make_shared<ov::op::v0::Convert>(kv_len_scalar.output(), ov::element::i32)->output(0), ctx);
+
+    // col indices: [1, kv_len], row indices: [q_len, 1] in absolute token positions.
+    auto col_indices = range(kv_len_i32, 0, 1, ov::element::i32).unsqueeze(0);
+    auto row_indices = range(cache_len_i32, cache_len_i32 + q_len_i32, 1, ov::element::i32).unsqueeze(1);
+    auto causal_cond = less_equal(col_indices, row_indices);  // [q_len, kv_len] bool
+
+    auto zero_val = Tensor(const_scalar(ctx, 0.0f), ctx);
+    auto neg_inf = Tensor(const_scalar(ctx, -65504.0f), ctx);
+
+    if (!attention_mask) {
+        auto mask_2d = where(causal_cond, zero_val, neg_inf);
+        auto mask_4d = mask_2d.unsqueeze({0, 1});
+        auto one_val = const_vec(ctx, std::vector<int64_t>{1});
+        auto target_shape = shape::make({batch, one_val, q_len_1d.output(), kv_len_1d.output()});
+        return shape::broadcast_to(mask_4d, target_shape);
+    }
+
+    // Combine causal and padding constraints in boolean space:
+    // attend = causal_cond && (attention_mask != 0), then map to {0, -inf}.
+    auto attn_i32 = Tensor(
+        std::make_shared<ov::op::v0::Convert>(attention_mask->output(), ov::element::i32)->output(0), ctx);
+    auto zero_i32 = Tensor(const_scalar(ctx, int32_t{0}), ctx);
+    auto valid_tokens = Tensor(
+        std::make_shared<ov::op::v1::NotEqual>(attn_i32.output(), zero_i32.output())->output(0), ctx);  // [B, kv_len]
+
+    auto causal_4d = causal_cond.unsqueeze({0, 1});      // [1, 1, q_len, kv_len]
+    auto valid_tokens_4d = valid_tokens.unsqueeze({1, 2});  // [B, 1, 1, kv_len]
+    auto can_attend = Tensor(
+        std::make_shared<ov::op::v1::LogicalAnd>(causal_4d.output(), valid_tokens_4d.output())->output(0), ctx);
+    auto combined_mask = where(can_attend, zero_val, neg_inf);  // [B, 1, q_len, kv_len]
+
+    // Keep NPU/NPUW-identifiable SDPA mask pattern.
+    auto zero_1d = const_vec(ctx, std::vector<int64_t>{0});
+    auto max_1d = const_vec(ctx, std::vector<int64_t>{std::numeric_limits<int64_t>::max()});
+    auto one_1d = const_vec(ctx, std::vector<int64_t>{1});
+    auto axis_1d = const_vec(ctx, std::vector<int64_t>{3});
+    auto slice_node = std::make_shared<ov::op::v8::Slice>(combined_mask.output(), zero_1d, max_1d, one_1d, axis_1d);
+    return Tensor(slice_node, ctx);
+}
+
+}  // namespace
+
 Tensor build_kv_causal_mask(const Tensor& q, const Tensor& k) {
     // Build causal mask for KV cache scenario:
     // Q: [batch, heads, q_len, head_dim]
@@ -210,155 +273,40 @@ Tensor build_kv_causal_mask(const Tensor& q, const Tensor& k) {
     // For prefill: q_len=N, kv_len=N, behaves like standard causal mask
     // For decode: q_len=1, kv_len=cache_len+1, allows attending to all positions
     auto* ctx = q.context();
-
-    // Get dimensions as shape [1] tensors
-    auto batch = shape::dim(q, 0);  // [1]
-    auto q_len = shape::dim(q, 2);  // [1]
-    auto kv_len = shape::dim(k, 2); // [1]
-
-    // Squeeze to scalars for Range op
-    auto q_len_scalar = Tensor(q_len, ctx).squeeze(0);
-    auto kv_len_scalar = Tensor(kv_len, ctx).squeeze(0);
-
-    // Calculate cache_seq_len = kv_len - q_len (as scalar)
-    auto cache_len_scalar = Tensor(
-        std::make_shared<ov::opset13::Subtract>(kv_len_scalar.output(), q_len_scalar.output())->output(0), ctx);
-
-    // Convert to i32 for Range
-    auto cache_len_i32 = Tensor(
-        std::make_shared<ov::op::v0::Convert>(cache_len_scalar.output(), ov::element::i32)->output(0), ctx);
-    auto q_len_i32 = Tensor(
-        std::make_shared<ov::op::v0::Convert>(q_len_scalar.output(), ov::element::i32)->output(0), ctx);
-    auto kv_len_i32 = Tensor(
-        std::make_shared<ov::op::v0::Convert>(kv_len_scalar.output(), ov::element::i32)->output(0), ctx);
-
-    // Create col indices: [0, 1, 2, ..., kv_len-1] -> [1, kv_len]
-    auto col_range = range(kv_len_i32, 0, 1, ov::element::i32);
-    auto col_indices = col_range.unsqueeze(0);  // [1, kv_len]
-
-    // Create row indices: [cache_len, cache_len+1, ..., cache_len+q_len-1] -> [q_len, 1]
-    // These represent the absolute positions of query tokens
-    auto q_len_plus_cache = cache_len_i32 + q_len_i32;
-    auto row_range = range(cache_len_i32, q_len_plus_cache, 1, ov::element::i32);
-    auto row_indices = row_range.unsqueeze(1);  // [q_len, 1]
-
-    // Causal condition: col <= row (attend to current and past positions)
-    auto causal_cond = less_equal(col_indices, row_indices);  // [q_len, kv_len]
-
-    // Build mask: 0 where can attend, -inf where masked
-    auto zero_val = Tensor(const_scalar(ctx, 0.0f), ctx);
-    auto neg_inf = Tensor(const_scalar(ctx, -65504.0f), ctx);
-    auto mask_2d = where(causal_cond, zero_val, neg_inf);  // [q_len, kv_len]
-
-    // Expand to [batch, 1, q_len, kv_len]
-    auto mask_4d = mask_2d.unsqueeze({0, 1});
-
-    // Broadcast to batch size
-    auto one_val = const_vec(ctx, std::vector<int64_t>{1});
-    auto target_shape = shape::make({batch, one_val, q_len, kv_len});
-    return shape::broadcast_to(mask_4d, target_shape);
+    auto batch = shape::dim(q, 0);
+    auto q_len = Tensor(shape::dim(q, 2), ctx);
+    auto kv_len = Tensor(shape::dim(k, 2), ctx);
+    return build_kv_causal_mask_impl(ctx, batch, q_len, kv_len, nullptr);
 }
 
 Tensor build_kv_causal_mask_with_attention(const Tensor& q, const Tensor& k, const Tensor& attention_mask) {
     // Build causal mask for KV cache scenario with attention_mask integration.
-    // This function produces a mask structure compatible with NPU/NPUW.
-    //
     // attention_mask: [batch, kv_len] where 1=attend, 0=mask (padding)
     // Q: [batch, heads, q_len, head_dim]
     // K: [batch, heads, kv_len, head_dim]
     // Output: [batch, 1, q_len, kv_len]
-    //
-    // The mask combines causal masking with attention_mask to handle both:
-    // 1. Causal constraint: only attend to current and past positions
-    // 2. Padding mask: don't attend to padded positions
-    
     auto* ctx = q.context();
+    auto batch = shape::dim(q, 0);
+    auto q_len = Tensor(shape::dim(q, 2), ctx);
+    auto kv_len = Tensor(shape::dim(k, 2), ctx);
+    return build_kv_causal_mask_impl(ctx, batch, q_len, kv_len, &attention_mask);
+}
 
-    // Get dimensions
-    auto batch = shape::dim(q, 0);  // [1]
-    auto q_len = shape::dim(q, 2);  // [1]
-    auto kv_len = shape::dim(k, 2); // [1]
+Tensor build_kv_causal_mask_with_attention_from_q_len(const Tensor& q_len, const Tensor& attention_mask) {
+    auto* ctx = q_len.context() ? q_len.context() : attention_mask.context();
+    if (q_len.context() && attention_mask.context() && q_len.context() != attention_mask.context()) {
+        OPENVINO_THROW("Tensor contexts do not match");
+    }
+    auto batch = shape::dim(attention_mask, 0);
+    auto kv_len = Tensor(shape::dim(attention_mask, 1), ctx);
 
-    // Squeeze to scalars for Range op
-    auto q_len_scalar = Tensor(q_len, ctx).squeeze(0);
-    auto kv_len_scalar = Tensor(kv_len, ctx).squeeze(0);
+    Tensor q_len_1d = q_len;
+    const auto q_rank = q_len.output().get_partial_shape().rank();
+    if (q_rank.is_static() && q_rank.get_length() == 0) {
+        q_len_1d = q_len.unsqueeze(0);
+    }
 
-    // Calculate cache_seq_len = kv_len - q_len (as scalar)
-    auto cache_len_scalar = Tensor(
-        std::make_shared<ov::opset13::Subtract>(kv_len_scalar.output(), q_len_scalar.output())->output(0), ctx);
-
-    // Convert to i32 for Range
-    auto cache_len_i32 = Tensor(
-        std::make_shared<ov::op::v0::Convert>(cache_len_scalar.output(), ov::element::i32)->output(0), ctx);
-    auto q_len_i32 = Tensor(
-        std::make_shared<ov::op::v0::Convert>(q_len_scalar.output(), ov::element::i32)->output(0), ctx);
-    auto kv_len_i32 = Tensor(
-        std::make_shared<ov::op::v0::Convert>(kv_len_scalar.output(), ov::element::i32)->output(0), ctx);
-
-    // Create col indices: [0, 1, 2, ..., kv_len-1] -> [1, kv_len]
-    auto col_range = range(kv_len_i32, 0, 1, ov::element::i32);
-    auto col_indices = col_range.unsqueeze(0);  // [1, kv_len]
-
-    // Create row indices: [cache_len, cache_len+1, ..., cache_len+q_len-1] -> [q_len, 1]
-    auto q_len_plus_cache = cache_len_i32 + q_len_i32;
-    auto row_range = range(cache_len_i32, q_len_plus_cache, 1, ov::element::i32);
-    auto row_indices = row_range.unsqueeze(1);  // [q_len, 1]
-
-    // Causal condition: col <= row (attend to current and past positions)
-    auto causal_cond = less_equal(col_indices, row_indices);  // [q_len, kv_len]
-
-    // Build mask values
-    auto zero_val = Tensor(const_scalar(ctx, 0.0f), ctx);
-    auto neg_inf = Tensor(const_scalar(ctx, -65504.0f), ctx);
-    
-    // Causal mask: 0 where can attend, -inf where masked
-    auto causal_mask_2d = where(causal_cond, zero_val, neg_inf);  // [q_len, kv_len]
-
-    // Process attention_mask: [batch, kv_len] -> [batch, 1, 1, kv_len]
-    // Convert attention_mask to float and create mask values
-    // attention_mask: 1=attend, 0=mask -> we need: 0 for attend, -inf for mask
-    auto attn_mask_f32 = Tensor(
-        std::make_shared<ov::op::v0::Convert>(attention_mask.output(), ov::element::f32)->output(0), ctx);
-    
-    // Create padding mask: where attention_mask==0, use -inf; where ==1, use 0
-    auto attn_zero = Tensor(const_scalar(ctx, 0.0f), ctx);
-    auto attn_mask_cond = Tensor(
-        std::make_shared<ov::op::v1::Equal>(attn_mask_f32.output(), attn_zero.output())->output(0), ctx);
-    auto padding_mask = where(attn_mask_cond, neg_inf, zero_val);  // [batch, kv_len]
-    
-    // Expand padding_mask to [batch, 1, 1, kv_len]
-    auto padding_mask_4d = padding_mask.unsqueeze({1, 2});  // [batch, 1, 1, kv_len]
-
-    // Expand causal_mask to [1, 1, q_len, kv_len] for broadcasting
-    auto causal_mask_4d = causal_mask_2d.unsqueeze({0, 1});  // [1, 1, q_len, kv_len]
-
-    // Combine masks: add causal_mask and padding_mask
-    // Result: positions that are either causally masked OR padding-masked get -inf
-    // This works because: 0 + 0 = 0, 0 + (-inf) = -inf, (-inf) + 0 = -inf, (-inf) + (-inf) = -inf
-    auto combined_mask = Tensor(
-        std::make_shared<ov::op::v1::Add>(causal_mask_4d.output(), padding_mask_4d.output())->output(0), ctx);
-    
-    // Clamp to -inf to handle the -inf + -inf = -inf*2 case
-    auto min_val = Tensor(const_scalar(ctx, -65504.0f), ctx);
-    auto clamped_mask = Tensor(
-        std::make_shared<ov::op::v1::Maximum>(combined_mask.output(), min_val.output())->output(0), ctx);
-
-    // NPU/NPUW compatibility: Add a passthrough Slice to make the mask identifiable.
-    // NPUW expects SDPA mask to come from a Slice node for proper processing.
-    auto zero_1d = const_vec(ctx, std::vector<int64_t>{0});
-    auto max_1d = const_vec(ctx, std::vector<int64_t>{std::numeric_limits<int64_t>::max()});
-    auto one_1d = const_vec(ctx, std::vector<int64_t>{1});
-    auto axis_1d = const_vec(ctx, std::vector<int64_t>{3});  // Last dimension
-    
-    auto slice_node = std::make_shared<ov::op::v8::Slice>(
-        clamped_mask.output(),
-        zero_1d,   // start: [0]
-        max_1d,    // stop: [max] (full slice)
-        one_1d,    // step: [1]
-        axis_1d    // axis: [3] (last dim)
-    );
-    
-    return Tensor(slice_node, ctx);
+    return build_kv_causal_mask_impl(ctx, batch, q_len_1d, kv_len, &attention_mask);
 }
 
 Tensor sdpa(const Tensor& q,

--- a/src/cpp/src/modeling/ops/llm.cpp
+++ b/src/cpp/src/modeling/ops/llm.cpp
@@ -361,6 +361,33 @@ Tensor build_kv_causal_mask_with_attention(const Tensor& q, const Tensor& k, con
     return Tensor(slice_node, ctx);
 }
 
+Tensor build_kv_causal_mask_with_attention_from_q_len(const Tensor& q_len, const Tensor& attention_mask) {
+    auto* ctx = q_len.context() ? q_len.context() : attention_mask.context();
+    if (!ctx) {
+        OPENVINO_THROW("Tensor context is null");
+    }
+    if (q_len.context() && attention_mask.context() && q_len.context() != attention_mask.context()) {
+        OPENVINO_THROW("Tensor contexts do not match");
+    }
+
+    Tensor q_len_1d = q_len;
+    const auto q_rank = q_len.output().get_partial_shape().rank();
+    if (q_rank.is_static() && q_rank.get_length() == 0) {
+        q_len_1d = q_len.unsqueeze(0);
+    }
+
+    auto batch = shape::dim(attention_mask, 0);
+    auto kv_len = shape::dim(attention_mask, 1);
+    auto one = const_vec(ctx, std::vector<int64_t>{1});
+    auto q_shape = shape::make({batch, one, q_len_1d.output(), one});
+    auto k_shape = shape::make({batch, one, kv_len, one});
+
+    auto zero = Tensor(const_scalar(ctx, 0.0f), ctx);
+    auto q_dummy = shape::broadcast_to(zero, q_shape);
+    auto k_dummy = shape::broadcast_to(zero, k_shape);
+    return build_kv_causal_mask_with_attention(q_dummy, k_dummy, attention_mask);
+}
+
 Tensor sdpa(const Tensor& q,
             const Tensor& k,
             const Tensor& v,

--- a/src/cpp/src/modeling/ops/llm.cpp
+++ b/src/cpp/src/modeling/ops/llm.cpp
@@ -201,69 +201,6 @@ Tensor causal_mask(const Tensor& scores) {
     return shape::broadcast_to(mask4d, scores_shape);
 }
 
-namespace {
-
-Tensor build_kv_causal_mask_impl(ov::genai::modeling::OpContext* ctx,
-                                 const ov::Output<ov::Node>& batch,
-                                 const Tensor& q_len_1d,
-                                 const Tensor& kv_len_1d,
-                                 const Tensor* attention_mask) {
-    // Squeeze [1] length tensors to scalars for Range ops.
-    auto q_len_scalar = q_len_1d.squeeze(0);
-    auto kv_len_scalar = kv_len_1d.squeeze(0);
-
-    // cache_len = kv_len - q_len.
-    auto cache_len_scalar = Tensor(
-        std::make_shared<ov::opset13::Subtract>(kv_len_scalar.output(), q_len_scalar.output())->output(0), ctx);
-
-    auto cache_len_i32 = Tensor(
-        std::make_shared<ov::op::v0::Convert>(cache_len_scalar.output(), ov::element::i32)->output(0), ctx);
-    auto q_len_i32 = Tensor(
-        std::make_shared<ov::op::v0::Convert>(q_len_scalar.output(), ov::element::i32)->output(0), ctx);
-    auto kv_len_i32 = Tensor(
-        std::make_shared<ov::op::v0::Convert>(kv_len_scalar.output(), ov::element::i32)->output(0), ctx);
-
-    // col indices: [1, kv_len], row indices: [q_len, 1] in absolute token positions.
-    auto col_indices = range(kv_len_i32, 0, 1, ov::element::i32).unsqueeze(0);
-    auto row_indices = range(cache_len_i32, cache_len_i32 + q_len_i32, 1, ov::element::i32).unsqueeze(1);
-    auto causal_cond = less_equal(col_indices, row_indices);  // [q_len, kv_len] bool
-
-    auto zero_val = Tensor(const_scalar(ctx, 0.0f), ctx);
-    auto neg_inf = Tensor(const_scalar(ctx, -65504.0f), ctx);
-
-    if (!attention_mask) {
-        auto mask_2d = where(causal_cond, zero_val, neg_inf);
-        auto mask_4d = mask_2d.unsqueeze({0, 1});
-        auto one_val = const_vec(ctx, std::vector<int64_t>{1});
-        auto target_shape = shape::make({batch, one_val, q_len_1d.output(), kv_len_1d.output()});
-        return shape::broadcast_to(mask_4d, target_shape);
-    }
-
-    // Combine causal and padding constraints in boolean space:
-    // attend = causal_cond && (attention_mask != 0), then map to {0, -inf}.
-    auto attn_i32 = Tensor(
-        std::make_shared<ov::op::v0::Convert>(attention_mask->output(), ov::element::i32)->output(0), ctx);
-    auto zero_i32 = Tensor(const_scalar(ctx, int32_t{0}), ctx);
-    auto valid_tokens = Tensor(
-        std::make_shared<ov::op::v1::NotEqual>(attn_i32.output(), zero_i32.output())->output(0), ctx);  // [B, kv_len]
-
-    auto causal_4d = causal_cond.unsqueeze({0, 1});      // [1, 1, q_len, kv_len]
-    auto valid_tokens_4d = valid_tokens.unsqueeze({1, 2});  // [B, 1, 1, kv_len]
-    auto can_attend = Tensor(
-        std::make_shared<ov::op::v1::LogicalAnd>(causal_4d.output(), valid_tokens_4d.output())->output(0), ctx);
-    auto combined_mask = where(can_attend, zero_val, neg_inf);  // [B, 1, q_len, kv_len]
-
-    // Keep NPU/NPUW-identifiable SDPA mask pattern.
-    auto zero_1d = const_vec(ctx, std::vector<int64_t>{0});
-    auto max_1d = const_vec(ctx, std::vector<int64_t>{std::numeric_limits<int64_t>::max()});
-    auto one_1d = const_vec(ctx, std::vector<int64_t>{1});
-    auto axis_1d = const_vec(ctx, std::vector<int64_t>{3});
-    auto slice_node = std::make_shared<ov::op::v8::Slice>(combined_mask.output(), zero_1d, max_1d, one_1d, axis_1d);
-    return Tensor(slice_node, ctx);
-}
-
-}  // namespace
-
 Tensor build_kv_causal_mask(const Tensor& q, const Tensor& k) {
     // Build causal mask for KV cache scenario:
     // Q: [batch, heads, q_len, head_dim]
@@ -273,40 +210,155 @@ Tensor build_kv_causal_mask(const Tensor& q, const Tensor& k) {
     // For prefill: q_len=N, kv_len=N, behaves like standard causal mask
     // For decode: q_len=1, kv_len=cache_len+1, allows attending to all positions
     auto* ctx = q.context();
-    auto batch = shape::dim(q, 0);
-    auto q_len = Tensor(shape::dim(q, 2), ctx);
-    auto kv_len = Tensor(shape::dim(k, 2), ctx);
-    return build_kv_causal_mask_impl(ctx, batch, q_len, kv_len, nullptr);
+
+    // Get dimensions as shape [1] tensors
+    auto batch = shape::dim(q, 0);  // [1]
+    auto q_len = shape::dim(q, 2);  // [1]
+    auto kv_len = shape::dim(k, 2); // [1]
+
+    // Squeeze to scalars for Range op
+    auto q_len_scalar = Tensor(q_len, ctx).squeeze(0);
+    auto kv_len_scalar = Tensor(kv_len, ctx).squeeze(0);
+
+    // Calculate cache_seq_len = kv_len - q_len (as scalar)
+    auto cache_len_scalar = Tensor(
+        std::make_shared<ov::opset13::Subtract>(kv_len_scalar.output(), q_len_scalar.output())->output(0), ctx);
+
+    // Convert to i32 for Range
+    auto cache_len_i32 = Tensor(
+        std::make_shared<ov::op::v0::Convert>(cache_len_scalar.output(), ov::element::i32)->output(0), ctx);
+    auto q_len_i32 = Tensor(
+        std::make_shared<ov::op::v0::Convert>(q_len_scalar.output(), ov::element::i32)->output(0), ctx);
+    auto kv_len_i32 = Tensor(
+        std::make_shared<ov::op::v0::Convert>(kv_len_scalar.output(), ov::element::i32)->output(0), ctx);
+
+    // Create col indices: [0, 1, 2, ..., kv_len-1] -> [1, kv_len]
+    auto col_range = range(kv_len_i32, 0, 1, ov::element::i32);
+    auto col_indices = col_range.unsqueeze(0);  // [1, kv_len]
+
+    // Create row indices: [cache_len, cache_len+1, ..., cache_len+q_len-1] -> [q_len, 1]
+    // These represent the absolute positions of query tokens
+    auto q_len_plus_cache = cache_len_i32 + q_len_i32;
+    auto row_range = range(cache_len_i32, q_len_plus_cache, 1, ov::element::i32);
+    auto row_indices = row_range.unsqueeze(1);  // [q_len, 1]
+
+    // Causal condition: col <= row (attend to current and past positions)
+    auto causal_cond = less_equal(col_indices, row_indices);  // [q_len, kv_len]
+
+    // Build mask: 0 where can attend, -inf where masked
+    auto zero_val = Tensor(const_scalar(ctx, 0.0f), ctx);
+    auto neg_inf = Tensor(const_scalar(ctx, -65504.0f), ctx);
+    auto mask_2d = where(causal_cond, zero_val, neg_inf);  // [q_len, kv_len]
+
+    // Expand to [batch, 1, q_len, kv_len]
+    auto mask_4d = mask_2d.unsqueeze({0, 1});
+
+    // Broadcast to batch size
+    auto one_val = const_vec(ctx, std::vector<int64_t>{1});
+    auto target_shape = shape::make({batch, one_val, q_len, kv_len});
+    return shape::broadcast_to(mask_4d, target_shape);
 }
 
 Tensor build_kv_causal_mask_with_attention(const Tensor& q, const Tensor& k, const Tensor& attention_mask) {
     // Build causal mask for KV cache scenario with attention_mask integration.
+    // This function produces a mask structure compatible with NPU/NPUW.
+    //
     // attention_mask: [batch, kv_len] where 1=attend, 0=mask (padding)
     // Q: [batch, heads, q_len, head_dim]
     // K: [batch, heads, kv_len, head_dim]
     // Output: [batch, 1, q_len, kv_len]
+    //
+    // The mask combines causal masking with attention_mask to handle both:
+    // 1. Causal constraint: only attend to current and past positions
+    // 2. Padding mask: don't attend to padded positions
+    
     auto* ctx = q.context();
-    auto batch = shape::dim(q, 0);
-    auto q_len = Tensor(shape::dim(q, 2), ctx);
-    auto kv_len = Tensor(shape::dim(k, 2), ctx);
-    return build_kv_causal_mask_impl(ctx, batch, q_len, kv_len, &attention_mask);
-}
 
-Tensor build_kv_causal_mask_with_attention_from_q_len(const Tensor& q_len, const Tensor& attention_mask) {
-    auto* ctx = q_len.context() ? q_len.context() : attention_mask.context();
-    if (q_len.context() && attention_mask.context() && q_len.context() != attention_mask.context()) {
-        OPENVINO_THROW("Tensor contexts do not match");
-    }
-    auto batch = shape::dim(attention_mask, 0);
-    auto kv_len = Tensor(shape::dim(attention_mask, 1), ctx);
+    // Get dimensions
+    auto batch = shape::dim(q, 0);  // [1]
+    auto q_len = shape::dim(q, 2);  // [1]
+    auto kv_len = shape::dim(k, 2); // [1]
 
-    Tensor q_len_1d = q_len;
-    const auto q_rank = q_len.output().get_partial_shape().rank();
-    if (q_rank.is_static() && q_rank.get_length() == 0) {
-        q_len_1d = q_len.unsqueeze(0);
-    }
+    // Squeeze to scalars for Range op
+    auto q_len_scalar = Tensor(q_len, ctx).squeeze(0);
+    auto kv_len_scalar = Tensor(kv_len, ctx).squeeze(0);
 
-    return build_kv_causal_mask_impl(ctx, batch, q_len_1d, kv_len, &attention_mask);
+    // Calculate cache_seq_len = kv_len - q_len (as scalar)
+    auto cache_len_scalar = Tensor(
+        std::make_shared<ov::opset13::Subtract>(kv_len_scalar.output(), q_len_scalar.output())->output(0), ctx);
+
+    // Convert to i32 for Range
+    auto cache_len_i32 = Tensor(
+        std::make_shared<ov::op::v0::Convert>(cache_len_scalar.output(), ov::element::i32)->output(0), ctx);
+    auto q_len_i32 = Tensor(
+        std::make_shared<ov::op::v0::Convert>(q_len_scalar.output(), ov::element::i32)->output(0), ctx);
+    auto kv_len_i32 = Tensor(
+        std::make_shared<ov::op::v0::Convert>(kv_len_scalar.output(), ov::element::i32)->output(0), ctx);
+
+    // Create col indices: [0, 1, 2, ..., kv_len-1] -> [1, kv_len]
+    auto col_range = range(kv_len_i32, 0, 1, ov::element::i32);
+    auto col_indices = col_range.unsqueeze(0);  // [1, kv_len]
+
+    // Create row indices: [cache_len, cache_len+1, ..., cache_len+q_len-1] -> [q_len, 1]
+    auto q_len_plus_cache = cache_len_i32 + q_len_i32;
+    auto row_range = range(cache_len_i32, q_len_plus_cache, 1, ov::element::i32);
+    auto row_indices = row_range.unsqueeze(1);  // [q_len, 1]
+
+    // Causal condition: col <= row (attend to current and past positions)
+    auto causal_cond = less_equal(col_indices, row_indices);  // [q_len, kv_len]
+
+    // Build mask values
+    auto zero_val = Tensor(const_scalar(ctx, 0.0f), ctx);
+    auto neg_inf = Tensor(const_scalar(ctx, -65504.0f), ctx);
+    
+    // Causal mask: 0 where can attend, -inf where masked
+    auto causal_mask_2d = where(causal_cond, zero_val, neg_inf);  // [q_len, kv_len]
+
+    // Process attention_mask: [batch, kv_len] -> [batch, 1, 1, kv_len]
+    // Convert attention_mask to float and create mask values
+    // attention_mask: 1=attend, 0=mask -> we need: 0 for attend, -inf for mask
+    auto attn_mask_f32 = Tensor(
+        std::make_shared<ov::op::v0::Convert>(attention_mask.output(), ov::element::f32)->output(0), ctx);
+    
+    // Create padding mask: where attention_mask==0, use -inf; where ==1, use 0
+    auto attn_zero = Tensor(const_scalar(ctx, 0.0f), ctx);
+    auto attn_mask_cond = Tensor(
+        std::make_shared<ov::op::v1::Equal>(attn_mask_f32.output(), attn_zero.output())->output(0), ctx);
+    auto padding_mask = where(attn_mask_cond, neg_inf, zero_val);  // [batch, kv_len]
+    
+    // Expand padding_mask to [batch, 1, 1, kv_len]
+    auto padding_mask_4d = padding_mask.unsqueeze({1, 2});  // [batch, 1, 1, kv_len]
+
+    // Expand causal_mask to [1, 1, q_len, kv_len] for broadcasting
+    auto causal_mask_4d = causal_mask_2d.unsqueeze({0, 1});  // [1, 1, q_len, kv_len]
+
+    // Combine masks: add causal_mask and padding_mask
+    // Result: positions that are either causally masked OR padding-masked get -inf
+    // This works because: 0 + 0 = 0, 0 + (-inf) = -inf, (-inf) + 0 = -inf, (-inf) + (-inf) = -inf
+    auto combined_mask = Tensor(
+        std::make_shared<ov::op::v1::Add>(causal_mask_4d.output(), padding_mask_4d.output())->output(0), ctx);
+    
+    // Clamp to -inf to handle the -inf + -inf = -inf*2 case
+    auto min_val = Tensor(const_scalar(ctx, -65504.0f), ctx);
+    auto clamped_mask = Tensor(
+        std::make_shared<ov::op::v1::Maximum>(combined_mask.output(), min_val.output())->output(0), ctx);
+
+    // NPU/NPUW compatibility: Add a passthrough Slice to make the mask identifiable.
+    // NPUW expects SDPA mask to come from a Slice node for proper processing.
+    auto zero_1d = const_vec(ctx, std::vector<int64_t>{0});
+    auto max_1d = const_vec(ctx, std::vector<int64_t>{std::numeric_limits<int64_t>::max()});
+    auto one_1d = const_vec(ctx, std::vector<int64_t>{1});
+    auto axis_1d = const_vec(ctx, std::vector<int64_t>{3});  // Last dimension
+    
+    auto slice_node = std::make_shared<ov::op::v8::Slice>(
+        clamped_mask.output(),
+        zero_1d,   // start: [0]
+        max_1d,    // stop: [max] (full slice)
+        one_1d,    // step: [1]
+        axis_1d    // axis: [3] (last dim)
+    );
+    
+    return Tensor(slice_node, ctx);
 }
 
 Tensor sdpa(const Tensor& q,

--- a/src/cpp/src/modeling/ops/llm.hpp
+++ b/src/cpp/src/modeling/ops/llm.hpp
@@ -22,8 +22,9 @@ std::pair<Tensor, Tensor> rope_cos_sin(const Tensor& positions,
 Tensor apply_rope(const Tensor& x,
                   const Tensor& cos,
                   const Tensor& sin,
-                  int32_t head_dim,
-                  const OpPolicy* policy = nullptr);
+                  int32_t rotary_ndims,
+                  const OpPolicy* policy = nullptr,
+                  int32_t head_size = -1);
 Tensor apply_rope_interleave(const Tensor& x,
                              const Tensor& cos,
                              const Tensor& sin,

--- a/src/cpp/src/modeling/ops/llm.hpp
+++ b/src/cpp/src/modeling/ops/llm.hpp
@@ -41,6 +41,9 @@ Tensor build_kv_causal_mask(const Tensor& q, const Tensor& k);
 // attention_mask: [batch, kv_len] where 1=attend, 0=mask (padding).
 // The attention_mask is incorporated into the causal mask to handle padding correctly.
 Tensor build_kv_causal_mask_with_attention(const Tensor& q, const Tensor& k, const Tensor& attention_mask);
+// Build the same causal+padding mask shape as build_kv_causal_mask_with_attention(), but from q_len and attention_mask.
+// q_len should be scalar or shape [1], and attention_mask is [batch, kv_len].
+Tensor build_kv_causal_mask_with_attention_from_q_len(const Tensor& q_len, const Tensor& attention_mask);
 // Helpers for handling qk_head_dim != v_head_dim in SDPA.
 Tensor pad_to_head_dim(const Tensor& x, int32_t head_dim, int32_t target_head_dim);
 Tensor slice_to_head_dim(const Tensor& x, int32_t head_dim, int32_t target_head_dim);

--- a/src/cpp/src/modeling/ops/llm.hpp
+++ b/src/cpp/src/modeling/ops/llm.hpp
@@ -41,6 +41,9 @@ Tensor build_kv_causal_mask(const Tensor& q, const Tensor& k);
 // attention_mask: [batch, kv_len] where 1=attend, 0=mask (padding).
 // The attention_mask is incorporated into the causal mask to handle padding correctly.
 Tensor build_kv_causal_mask_with_attention(const Tensor& q, const Tensor& k, const Tensor& attention_mask);
+// Build causal+padding mask using q_len and attention_mask (kv_len inferred from attention_mask).
+// q_len must be a rank-1 tensor with one element.
+Tensor build_kv_causal_mask_with_attention_from_q_len(const Tensor& q_len, const Tensor& attention_mask);
 // Helpers for handling qk_head_dim != v_head_dim in SDPA.
 Tensor pad_to_head_dim(const Tensor& x, int32_t head_dim, int32_t target_head_dim);
 Tensor slice_to_head_dim(const Tensor& x, int32_t head_dim, int32_t target_head_dim);

--- a/src/cpp/src/modeling/ops/llm.hpp
+++ b/src/cpp/src/modeling/ops/llm.hpp
@@ -41,9 +41,6 @@ Tensor build_kv_causal_mask(const Tensor& q, const Tensor& k);
 // attention_mask: [batch, kv_len] where 1=attend, 0=mask (padding).
 // The attention_mask is incorporated into the causal mask to handle padding correctly.
 Tensor build_kv_causal_mask_with_attention(const Tensor& q, const Tensor& k, const Tensor& attention_mask);
-// Build causal+padding mask using q_len and attention_mask (kv_len inferred from attention_mask).
-// q_len must be a rank-1 tensor with one element.
-Tensor build_kv_causal_mask_with_attention_from_q_len(const Tensor& q_len, const Tensor& attention_mask);
 // Helpers for handling qk_head_dim != v_head_dim in SDPA.
 Tensor pad_to_head_dim(const Tensor& x, int32_t head_dim, int32_t target_head_dim);
 Tensor slice_to_head_dim(const Tensor& x, int32_t head_dim, int32_t target_head_dim);

--- a/src/cpp/src/modeling/ops/ops.cpp
+++ b/src/cpp/src/modeling/ops/ops.cpp
@@ -124,7 +124,8 @@ std::pair<Tensor, Tensor> linear_attention(const Tensor& q,
 std::pair<Tensor, Tensor> fused_conv(const Tensor& input,
                                      const Tensor& conv_weight,
                                      const Tensor& beam_idx,
-                                     const Tensor& initial_state) {
+                                     const Tensor& initial_state,
+                                     const std::shared_ptr<ov::op::util::Variable>& variable) {
     auto* ctx = input.context();
     const Tensor* inputs[] = {&conv_weight, &beam_idx, &initial_state};
     for (const auto* t : inputs) {
@@ -139,7 +140,7 @@ std::pair<Tensor, Tensor> fused_conv(const Tensor& input,
 
     ov::OutputVector args = {input.output(), conv_weight.output(),
                              beam_idx.output(), initial_state.output()};
-    auto node = std::make_shared<ov::op::FusedConv>(args);
+    auto node = std::make_shared<ov::op::FusedConv>(args, variable);
     return {Tensor(node->output(0), ctx), Tensor(node->output(1), ctx)};
 }
 

--- a/src/cpp/src/modeling/ops/ops.cpp
+++ b/src/cpp/src/modeling/ops/ops.cpp
@@ -5,6 +5,7 @@
 
 #include <openvino/core/except.hpp>
 #include <openvino/op/linear_attn.hpp>
+#include <openvino/op/fused_conv.hpp>
 #include <openvino/opsets/opset13.hpp>
 #include <openvino/op/placeholder_extension.hpp>
 #include <openvino/op/moe_3gemm_fused_compressed.hpp>
@@ -117,6 +118,28 @@ std::pair<Tensor, Tensor> linear_attention(const Tensor& q,
     // the C++ API parameter order), so we pass g before beta here.
     ov::OutputVector args = {q.output(), k.output(), v.output(), g.output(), beta.output(), initial_state.output()};
     auto node = std::make_shared<ov::op::LinearAttention>(args);
+    return {Tensor(node->output(0), ctx), Tensor(node->output(1), ctx)};
+}
+
+std::pair<Tensor, Tensor> fused_conv(const Tensor& input,
+                                     const Tensor& conv_weight,
+                                     const Tensor& beam_idx,
+                                     const Tensor& initial_state) {
+    auto* ctx = input.context();
+    const Tensor* inputs[] = {&conv_weight, &beam_idx, &initial_state};
+    for (const auto* t : inputs) {
+        auto* t_ctx = t->context();
+        if (ctx && t_ctx && ctx != t_ctx) {
+            OPENVINO_THROW("Tensor contexts do not match");
+        }
+        if (!ctx) {
+            ctx = t_ctx;
+        }
+    }
+
+    ov::OutputVector args = {input.output(), conv_weight.output(),
+                             beam_idx.output(), initial_state.output()};
+    auto node = std::make_shared<ov::op::FusedConv>(args);
     return {Tensor(node->output(0), ctx), Tensor(node->output(1), ctx)};
 }
 

--- a/src/cpp/src/modeling/ops/ops.hpp
+++ b/src/cpp/src/modeling/ops/ops.hpp
@@ -29,6 +29,10 @@ std::pair<Tensor, Tensor> linear_attention(const Tensor& q,
                                            const Tensor& beta,
                                            const Tensor& g,
                                            const Tensor& initial_state);
+std::pair<Tensor, Tensor> fused_conv(const Tensor& input,
+                                     const Tensor& conv_weight,
+                                     const Tensor& beam_idx,
+                                     const Tensor& initial_state);
 Tensor moe3gemm_fused_compressed(const Tensor& input,
                                  const Tensor& gate_inp_weight,
                                  const Tensor& gate_exps_weight,

--- a/src/cpp/src/modeling/ops/ops.hpp
+++ b/src/cpp/src/modeling/ops/ops.hpp
@@ -3,7 +3,10 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
+
+#include <openvino/op/util/variable.hpp>
 
 #include "modeling/ops/tensor.hpp"
 
@@ -32,7 +35,8 @@ std::pair<Tensor, Tensor> linear_attention(const Tensor& q,
 std::pair<Tensor, Tensor> fused_conv(const Tensor& input,
                                      const Tensor& conv_weight,
                                      const Tensor& beam_idx,
-                                     const Tensor& initial_state);
+                                     const Tensor& initial_state,
+                                     const std::shared_ptr<ov::op::util::Variable>& variable);
 Tensor moe3gemm_fused_compressed(const Tensor& input,
                                  const Tensor& gate_inp_weight,
                                  const Tensor& gate_exps_weight,

--- a/src/cpp/src/modeling/samples/modeling_qwen3_5.cpp
+++ b/src/cpp/src/modeling/samples/modeling_qwen3_5.cpp
@@ -913,6 +913,12 @@ int main(int argc, char* argv[]) try {
             }
         }
     }
+    // Pre-allocate USM-host tensor for decode position_ids - reuse across steps
+    // to avoid per-step create_host_tensor() + memcpy overhead.
+    // Shape: [3, batch, 1] (3 planes of identical position values per batch element)
+    ov::Tensor usm_decode_pos = make_usm_host_tensor(gpu_ctx, ov::element::i64, {3, batch, 1});
+    const int64_t* rope_deltas_data = plan.rope_deltas.data<const int64_t>();
+
     size_t decode_steps = 0;
     const auto decode_start = std::chrono::steady_clock::now();
     for (int step = 1; step < opts.max_new_tokens; ++step) {
@@ -924,11 +930,14 @@ int main(int argc, char* argv[]) try {
             step_data[b] = next_id;
         }
 
-        auto position_ids = ov::genai::modeling::models::Qwen3_5InputPlanner::build_decode_position_ids(
-            plan.rope_deltas,
-            past_len,
-            1);
-        auto usm_decode_pos = clone_as_usm_host(gpu_ctx, position_ids);
+        // Fill position_ids in-place: all 3 planes get the same value per batch element
+        auto* pos_data = usm_decode_pos.data<int64_t>();
+        for (size_t b = 0; b < batch; ++b) {
+            const int64_t value = past_len + rope_deltas_data[b];
+            pos_data[b] = value;             // plane 0
+            pos_data[batch + b] = value;     // plane 1
+            pos_data[2 * batch + b] = value; // plane 2
+        }
 
         text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kInputIds, step_ids);
         text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kAttentionMask, step_mask);

--- a/src/cpp/src/modeling/samples/modeling_qwen3_5.cpp
+++ b/src/cpp/src/modeling/samples/modeling_qwen3_5.cpp
@@ -372,6 +372,42 @@ ov::Tensor make_zero_tensor(const ov::element::Type& type, const ov::Shape& shap
     return tensor;
 }
 
+// ---------------------------------------------------------------------------
+// USM-host tensor helpers — iGPU zero-copy optimization
+// ---------------------------------------------------------------------------
+// On iGPU, GPU can access USM-host memory directly without H2D copy.
+// This eliminates the costly wait_for_events overhead for each input tensor.
+// Falls back to standard ov::Tensor when the context doesn't support it.
+
+/// Try to get the GPU RemoteContext from a CompiledModel.
+std::optional<ov::RemoteContext> try_get_gpu_context(ov::CompiledModel& compiled) {
+    try {
+        return compiled.get_context();
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+/// Create a USM-host tensor of given type/shape via the GPU context.
+ov::Tensor make_usm_host_tensor(std::optional<ov::RemoteContext>& ctx,
+                                const ov::element::Type& type,
+                                const ov::Shape& shape) {
+    if (ctx.has_value()) {
+        try {
+            return ctx->create_host_tensor(type, shape);
+        } catch (...) {}
+    }
+    return ov::Tensor(type, shape);
+}
+
+/// Create a USM-host tensor and copy data from an existing tensor.
+ov::Tensor clone_as_usm_host(std::optional<ov::RemoteContext>& ctx,
+                              const ov::Tensor& src) {
+    auto dst = make_usm_host_tensor(ctx, src.get_element_type(), src.get_shape());
+    std::memcpy(dst.data(), src.data(), src.get_byte_size());
+    return dst;
+}
+
 std::string resolve_pos_embed_name(ov::genai::modeling::weights::WeightSource& source) {
     const std::vector<std::string> candidates = {
         "model.visual.pos_embed.weight",
@@ -795,14 +831,26 @@ int main(int argc, char* argv[]) try {
 
     auto beam_idx = make_beam_idx(batch);
     auto text_request = compiled_text.create_infer_request();
+
+    // Get GPU context for USM-host tensors (iGPU zero-copy optimization)
+    auto gpu_ctx = try_get_gpu_context(compiled_text);
+
+    // Clone prefill inputs as USM-host for zero-copy on iGPU
+    auto usm_input_ids = clone_as_usm_host(gpu_ctx, input_ids);
+    auto usm_attention_mask = clone_as_usm_host(gpu_ctx, attention_mask);
+    auto usm_position_ids = clone_as_usm_host(gpu_ctx, plan.position_ids);
+    auto usm_beam_idx = clone_as_usm_host(gpu_ctx, beam_idx);
+
     text_request.reset_state();
-    text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kInputIds, input_ids);
-    text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kAttentionMask, attention_mask);
-    text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kPositionIds, plan.position_ids);
-    text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kBeamIdx, beam_idx);
+    text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kInputIds, usm_input_ids);
+    text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kAttentionMask, usm_attention_mask);
+    text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kPositionIds, usm_position_ids);
+    text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kBeamIdx, usm_beam_idx);
     if (use_vl) {
-        text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kVisualEmbeds, visual_padded);
-        text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kVisualPosMask, plan.visual_pos_mask);
+        auto usm_visual_padded = clone_as_usm_host(gpu_ctx, visual_padded);
+        auto usm_visual_pos_mask = clone_as_usm_host(gpu_ctx, plan.visual_pos_mask);
+        text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kVisualEmbeds, usm_visual_padded);
+        text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kVisualPosMask, usm_visual_pos_mask);
     }
 
     const auto prefill_start = std::chrono::steady_clock::now();
@@ -818,8 +866,8 @@ int main(int argc, char* argv[]) try {
     const auto stop_token_ids = resolve_stop_token_ids(use_dummy_mode_flag ? std::filesystem::path{} : model_dir,
                                                        tokenizer.get());
 
-    ov::Tensor step_ids(ov::element::i64, {batch, 1});
-    ov::Tensor step_mask(ov::element::i64, {batch, 1});
+    ov::Tensor step_ids = make_usm_host_tensor(gpu_ctx, ov::element::i64, {batch, 1});
+    ov::Tensor step_mask = make_usm_host_tensor(gpu_ctx, ov::element::i64, {batch, 1});
     auto* step_mask_data = step_mask.data<int64_t>();
     for (size_t b = 0; b < batch; ++b) {
         step_mask_data[b] = 1;
@@ -828,8 +876,10 @@ int main(int argc, char* argv[]) try {
     ov::Tensor decode_visual;
     ov::Tensor decode_visual_mask;
     if (use_vl) {
-        decode_visual = make_zero_tensor(ov::element::f32, {batch, 1, static_cast<size_t>(cfg.text.hidden_size)});
-        decode_visual_mask = make_zero_tensor(ov::element::boolean, {batch, 1});
+        decode_visual = make_usm_host_tensor(gpu_ctx, ov::element::f32, {batch, 1, static_cast<size_t>(cfg.text.hidden_size)});
+        std::memset(decode_visual.data(), 0, decode_visual.get_byte_size());
+        decode_visual_mask = make_usm_host_tensor(gpu_ctx, ov::element::boolean, {batch, 1});
+        std::memset(decode_visual_mask.data(), 0, decode_visual_mask.get_byte_size());
     }
 
     int64_t past_len = prompt_len;
@@ -878,11 +928,12 @@ int main(int argc, char* argv[]) try {
             plan.rope_deltas,
             past_len,
             1);
+        auto usm_decode_pos = clone_as_usm_host(gpu_ctx, position_ids);
 
         text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kInputIds, step_ids);
         text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kAttentionMask, step_mask);
-        text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kPositionIds, position_ids);
-        text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kBeamIdx, beam_idx);
+        text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kPositionIds, usm_decode_pos);
+        text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kBeamIdx, usm_beam_idx);
         if (use_vl) {
             text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kVisualEmbeds, decode_visual);
             text_request.set_tensor(ov::genai::modeling::models::Qwen3_5TextIO::kVisualPosMask, decode_visual_mask);

--- a/src/cpp/src/modeling/tests/llm_ops_test.cpp
+++ b/src/cpp/src/modeling/tests/llm_ops_test.cpp
@@ -92,6 +92,34 @@ std::vector<float> apply_rope_interleave_ref(const std::vector<float>& x,
     return out;
 }
 
+std::vector<float> apply_rope_partial_ref(const std::vector<float>& x,
+                                          const std::vector<float>& cos,
+                                          const std::vector<float>& sin,
+                                          size_t batch,
+                                          size_t heads,
+                                          size_t seq_len,
+                                          int32_t head_dim,
+                                          int32_t rotary_ndims) {
+    const int32_t half_rotary_ndims = rotary_ndims / 2;
+    std::vector<float> out = x;
+    for (size_t b = 0; b < batch; ++b) {
+        for (size_t h = 0; h < heads; ++h) {
+            for (size_t s = 0; s < seq_len; ++s) {
+                const size_t base = ((b * heads + h) * seq_len + s) * static_cast<size_t>(head_dim);
+                for (int32_t i = 0; i < half_rotary_ndims; ++i) {
+                    const float c = cos[(b * seq_len + s) * static_cast<size_t>(half_rotary_ndims) + static_cast<size_t>(i)];
+                    const float sn = sin[(b * seq_len + s) * static_cast<size_t>(half_rotary_ndims) + static_cast<size_t>(i)];
+                    const float x1 = x[base + static_cast<size_t>(i)];
+                    const float x2 = x[base + static_cast<size_t>(half_rotary_ndims + i)];
+                    out[base + static_cast<size_t>(i)] = x1 * c - x2 * sn;
+                    out[base + static_cast<size_t>(half_rotary_ndims + i)] = x1 * sn + x2 * c;
+                }
+            }
+        }
+    }
+    return out;
+}
+
 }  // namespace
 
 TEST(LLMOps, ApplyRopeInterleaveMatchesReference) {
@@ -133,6 +161,57 @@ TEST(LLMOps, ApplyRopeInterleaveMatchesReference) {
     request.set_input_tensor(1, cos_tensor);
 
     ov::Tensor sin_tensor(ov::element::f32, {batch, seq_len, static_cast<size_t>(half_dim)});
+    std::memcpy(sin_tensor.data(), sin_data.data(), sin_data.size() * sizeof(float));
+    request.set_input_tensor(2, sin_tensor);
+
+    request.infer();
+
+    test_utils::expect_tensor_near(request.get_output_tensor(), expected, test_utils::k_tol_default);
+}
+
+TEST(LLMOps, ApplyRopePartialHeadMatchesReference) {
+    ov::genai::modeling::BuilderContext ctx;
+
+    const size_t batch = 1;
+    const size_t heads = 2;
+    const size_t seq_len = 2;
+    const int32_t head_dim = 8;
+    const int32_t rotary_ndims = 4;
+    const int32_t half_rotary_ndims = rotary_ndims / 2;
+    const float rope_theta = 10000.0f;
+
+    auto x = ctx.parameter("x", ov::element::f32, ov::PartialShape{batch, heads, seq_len, head_dim});
+    auto cos = ctx.parameter("cos", ov::element::f32, ov::PartialShape{batch, seq_len, half_rotary_ndims});
+    auto sin = ctx.parameter("sin", ov::element::f32, ov::PartialShape{batch, seq_len, half_rotary_ndims});
+
+    auto out = ov::genai::modeling::ops::llm::apply_rope(x, cos, sin, rotary_ndims, nullptr, head_dim);
+    auto ov_model = ctx.build_model({out.output()});
+
+    ov::Core core;
+    auto compiled = core.compile_model(ov_model, "GPU");
+    auto request = compiled.create_infer_request();
+
+    const std::vector<float> x_data = {
+        0.1f, 0.2f, 0.3f, 0.4f, 9.1f, 9.2f, 9.3f, 9.4f,
+        0.5f, 0.6f, 0.7f, 0.8f, 9.5f, 9.6f, 9.7f, 9.8f,
+        1.1f, 1.2f, 1.3f, 1.4f, 8.1f, 8.2f, 8.3f, 8.4f,
+        1.5f, 1.6f, 1.7f, 1.8f, 8.5f, 8.6f, 8.7f, 8.8f,
+    };
+    const std::vector<int64_t> positions = {0, 1};
+    const auto cos_data = make_rope_cos(positions, batch, seq_len, rotary_ndims, rope_theta);
+    const auto sin_data = make_rope_sin(positions, batch, seq_len, rotary_ndims, rope_theta);
+    const auto expected =
+        apply_rope_partial_ref(x_data, cos_data, sin_data, batch, heads, seq_len, head_dim, rotary_ndims);
+
+    ov::Tensor x_tensor(ov::element::f32, {batch, heads, seq_len, static_cast<size_t>(head_dim)});
+    std::memcpy(x_tensor.data(), x_data.data(), x_data.size() * sizeof(float));
+    request.set_input_tensor(0, x_tensor);
+
+    ov::Tensor cos_tensor(ov::element::f32, {batch, seq_len, static_cast<size_t>(half_rotary_ndims)});
+    std::memcpy(cos_tensor.data(), cos_data.data(), cos_data.size() * sizeof(float));
+    request.set_input_tensor(1, cos_tensor);
+
+    ov::Tensor sin_tensor(ov::element::f32, {batch, seq_len, static_cast<size_t>(half_rotary_ndims)});
     std::memcpy(sin_tensor.data(), sin_data.data(), sin_data.size() * sizeof(float));
     request.set_input_tensor(2, sin_tensor);
 


### PR DESCRIPTION
## Timing Summary

| Test | TTFT | Throughput | Duration |
| --- | --- | --- | --- |
| 37: Huggingface Qwen3.5-35B-A3B modeling_qwen3_5 text | 1837.65 ms | 41.70 tokens/s | 5m51.78s |
| 38: Huggingface Qwen3.5-35B-A3B modeling_qwen3_5 vl | 3567.52 ms | 37.95 tokens/s | 6m06.38s |
| 37: Huggingface Qwen3.5-35B-A3B modeling_qwen3_5 text | 1906.07 ms | 43.08 tokens/s | 42.65s |
| 38: Huggingface Qwen3.5-35B-A3B modeling_qwen3_5 vl | 1995.76 ms | 42.19 tokens/s | 48.98s |
| 37: Huggingface Qwen3.5-35B-A3B modeling_qwen3_5 text | 1895.05 ms | 43.26 tokens/s | 43.43s |
| 38: Huggingface Qwen3.5-35B-A3B modeling_qwen3_5 vl | 1926.70 ms | 41.86 tokens/s | 48.73s |
| 37: Huggingface Qwen3.5-35B-A3B modeling_qwen3_5 text | 1886.50 ms | 42.58 tokens/s | 45.51s |
| 38: Huggingface Qwen3.5-35B-A3B modeling_qwen3_5 vl | 1938.21 ms | 42.33 tokens/s | 49.35s |
| 37: Huggingface Qwen3.5-35B-A3B modeling_qwen3_5 text | 1939.26 ms | 40.74 tokens/s | 43.86s |
| 38: Huggingface Qwen3.5-35B-A3B modeling_qwen3_5 vl | 2010.06 ms | 40.79 tokens/s | 49.59s |

Total duration: 18m10.36s