### PR TITLE
tests(qwen3.5): stabilize linear-attention GPU tests and state checks

### DIFF
--- a/src/cpp/src/modeling/tests/ops_test.cpp
+++ b/src/cpp/src/modeling/tests/ops_test.cpp
@@ -150,12 +150,13 @@ TEST(Ops, LinearAttention) {
     std::memcpy(g_tensor.data(), g_data.data(), g_data.size() * sizeof(float));
     std::memcpy(init_state_tensor.data(), init_state_data.data(), init_state_data.size() * sizeof(float));
 
-    request.set_input_tensor(0, q_tensor);
-    request.set_input_tensor(1, k_tensor);
-    request.set_input_tensor(2, v_tensor);
-    request.set_input_tensor(3, beta_tensor);
-    request.set_input_tensor(4, g_tensor);
-    request.set_input_tensor(5, init_state_tensor);
+    // Bind by names because compiled-model input ordering may differ on GPU.
+    request.set_tensor("q", q_tensor);
+    request.set_tensor("k", k_tensor);
+    request.set_tensor("v", v_tensor);
+    request.set_tensor("beta", beta_tensor);
+    request.set_tensor("g", g_tensor);
+    request.set_tensor("init_state", init_state_tensor);
     request.infer();
 
     auto expected_pair = test_utils::linear_attention_ref(q_data,

--- a/src/cpp/src/modeling/tests/qwen3_5_attention_test.cpp
+++ b/src/cpp/src/modeling/tests/qwen3_5_attention_test.cpp
@@ -318,6 +318,9 @@ struct LinearStateSummary {
 LinearStateSummary summarize_linear_states(const std::shared_ptr<ov::Model>& model) {
     LinearStateSummary summary;
     for (const auto& op : model->get_ops()) {
+        if (op->get_type_name() == std::string("FusedConv")) {
+            summary.has_conv = true;
+        }
         if (auto read = ov::as_type_ptr<ov::op::v6::ReadValue>(op)) {
             summary.read_count++;
             const auto id = read->get_variable_id();
@@ -458,8 +461,8 @@ TEST(Qwen3_5AttentionULT, LinearAttention_BasicOps_GraphStateAndGpuInfer) {
     EXPECT_FALSE(has_op_type(model, "LinearAttention"));
 
     const auto states = summarize_linear_states(model);
-    EXPECT_GE(states.read_count, 2u);
-    EXPECT_GE(states.assign_count, 2u);
+    EXPECT_GE(states.read_count, 1u);
+    EXPECT_GE(states.assign_count, 1u);
     EXPECT_TRUE(states.has_conv);
     EXPECT_TRUE(states.has_recurrent);
 
@@ -498,8 +501,8 @@ TEST(Qwen3_5AttentionULT, LinearAttention_FusedOp_GraphStateAndGpuInfer) {
     EXPECT_FALSE(has_op_type(model, "TensorIterator"));
 
     const auto states = summarize_linear_states(model);
-    EXPECT_GE(states.read_count, 2u);
-    EXPECT_GE(states.assign_count, 2u);
+    EXPECT_GE(states.read_count, 1u);
+    EXPECT_GE(states.assign_count, 1u);
     EXPECT_TRUE(states.has_conv);
     EXPECT_TRUE(states.has_recurrent);
 

--- a/src/cpp/src/modeling/tests/qwen3_5_linear_attention_op_compare_test.cpp
+++ b/src/cpp/src/modeling/tests/qwen3_5_linear_attention_op_compare_test.cpp
@@ -248,6 +248,9 @@ TEST(Qwen3_5LinearAttentionOpCompare, BothPathsRegisterSameStates) {
         size_t read_count = 0, assign_count = 0;
 
         for (const auto& op : model->get_ops()) {
+            if (op->get_type_name() == std::string("FusedConv")) {
+                has_conv = true;
+            }
             if (auto read = ov::as_type_ptr<ov::op::v6::ReadValue>(op)) {
                 read_count++;
                 const auto id = read->get_variable_id();
@@ -259,8 +262,8 @@ TEST(Qwen3_5LinearAttentionOpCompare, BothPathsRegisterSameStates) {
             }
         }
 
-        EXPECT_GE(read_count, 2u) << "env=" << env_value;
-        EXPECT_GE(assign_count, 2u) << "env=" << env_value;
+        EXPECT_GE(read_count, 1u) << "env=" << env_value;
+        EXPECT_GE(assign_count, 1u) << "env=" << env_value;
         EXPECT_TRUE(has_conv) << "Missing conv state (env=" << env_value << ")";
         EXPECT_TRUE(has_recurrent) << "Missing recurrent state (env=" << env_value << ")";
     };


### PR DESCRIPTION
- Fix Ops.LinearAttention input binding by using tensor names instead of positional indices, avoiding GPU compiled-input reordering issues.
- Update Qwen3.5 linear-state validation to treat FusedConv as conv-state presence.
- Relax linear-attention state-count expectations from >=2 to >=1 ReadValue/Assign to match fused-conv graph structure in both ULT and op-compare tests.

