### PR TITLE
Use variable-aware LinearAttention op, remove Assign sinks

### DIFF
--- a/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
+++ b/src/cpp/src/modeling/models/qwen3_5/modeling_qwen3_5_text.cpp
@@ -528,20 +528,22 @@ Tensor Qwen3_5GatedDeltaNet::forward(const Tensor& hidden_states,
                                               ov::element::f32,
                                               state_prefix + ".recurrent"};
     auto recurrent_var = std::make_shared<ov::op::util::Variable>(recurrent_info);
-    auto recurrent_read = std::make_shared<ov::op::v6::ReadValue>(recurrent_init.output(), recurrent_var);
-    auto recurrent_cached = ops::gather(Tensor(recurrent_read->output(0), op_ctx), beam_idx, 0);
 
     Tensor core_attn_tensor;  // [B, S, num_v_heads, head_v_dim]
 
     if (use_linear_attention_op()) {
-        // ── Fused LinearAttention op path ──
-        auto la_result = ops::linear_attention(q_f32, k_f32, v_f32, beta, g, recurrent_cached);
+        // ── Fused LinearAttention op path (mirrors FusedConv pattern) ──
+        // No ReadValue/Assign — LinearAttention manages the variable exclusively.
+        // The GPU impl reads from variable memory (if set) or from recurrent_init (first iteration),
+        // and writes updated state directly to variable memory.
+        auto la_result = ops::linear_attention(q_f32, k_f32, v_f32, beta, g, recurrent_init, recurrent_var);
         core_attn_tensor = la_result.first;   // [B, S, num_v_heads, head_v_dim]
-        auto recurrent_final = la_result.second;  // [B, num_v_heads, head_k_dim, head_v_dim]
-        auto recurrent_assign = std::make_shared<ov::opset13::Assign>(recurrent_final.output(), recurrent_var);
-        ctx().register_sink(recurrent_assign);
     } else {
         // ── TensorIterator path (default) ──
+        // Traditional ReadValue + Gather + Assign pattern for variable state management.
+        auto recurrent_read = std::make_shared<ov::op::v6::ReadValue>(recurrent_init.output(), recurrent_var);
+        auto recurrent_cached = ops::gather(Tensor(recurrent_read->output(0), op_ctx), beam_idx, 0);
+
         auto q_ss = Tensor(std::make_shared<ov::op::v1::ReduceSum>(q_f32.pow(2.0f).output(), reduce_kdim, true), op_ctx);
         auto k_ss = Tensor(std::make_shared<ov::op::v1::ReduceSum>(k_f32.pow(2.0f).output(), reduce_kdim, true), op_ctx);
         auto q_normed = q_f32 * (q_ss + 1e-6f).rsqrt();

--- a/src/cpp/src/modeling/ops/ops.cpp
+++ b/src/cpp/src/modeling/ops/ops.cpp
@@ -121,6 +121,32 @@ std::pair<Tensor, Tensor> linear_attention(const Tensor& q,
     return {Tensor(node->output(0), ctx), Tensor(node->output(1), ctx)};
 }
 
+std::pair<Tensor, Tensor> linear_attention(const Tensor& q,
+                                           const Tensor& k,
+                                           const Tensor& v,
+                                           const Tensor& beta,
+                                           const Tensor& g,
+                                           const Tensor& initial_state,
+                                           const std::shared_ptr<ov::op::util::Variable>& variable) {
+    auto* ctx = q.context();
+    const Tensor* inputs[] = {&k, &v, &beta, &g, &initial_state};
+    for (const auto* t : inputs) {
+        auto* t_ctx = t->context();
+        if (ctx && t_ctx && ctx != t_ctx) {
+            OPENVINO_THROW("Tensor contexts do not match");
+        }
+        if (!ctx) {
+            ctx = t_ctx;
+        }
+    }
+
+    // Note: the OCL kernel expects input[3]=g, input[4]=beta (swapped relative to
+    // the C++ API parameter order), so we pass g before beta here.
+    ov::OutputVector args = {q.output(), k.output(), v.output(), g.output(), beta.output(), initial_state.output()};
+    auto node = std::make_shared<ov::op::LinearAttention>(args, variable);
+    return {Tensor(node->output(0), ctx), Tensor(node->output(1), ctx)};
+}
+
 std::pair<Tensor, Tensor> fused_conv(const Tensor& input,
                                      const Tensor& conv_weight,
                                      const Tensor& beam_idx,

--- a/src/cpp/src/modeling/ops/ops.hpp
+++ b/src/cpp/src/modeling/ops/ops.hpp
@@ -32,6 +32,13 @@ std::pair<Tensor, Tensor> linear_attention(const Tensor& q,
                                            const Tensor& beta,
                                            const Tensor& g,
                                            const Tensor& initial_state);
+std::pair<Tensor, Tensor> linear_attention(const Tensor& q,
+                                           const Tensor& k,
+                                           const Tensor& v,
+                                           const Tensor& beta,
+                                           const Tensor& g,
+                                           const Tensor& initial_state,
+                                           const std::shared_ptr<ov::op::util::Variable>& variable);
 std::pair<Tensor, Tensor> fused_conv(const Tensor& input,
                                      const Tensor& conv_weight,
                                      const Tensor& beam_idx,


### PR DESCRIPTION
Make LinearAttention manage recurrent state variable exclusively (FusedConv pattern): no ReadValue/Assign in the fused path. Move ReadValue+Gather into TensorIterator fallback branch only. Pass recurrent_init directly to ops::linear_attention()