### PR TITLE
Enable Qwen3-ASR model with sample app, and tests

### DIFF
--- a/src/cpp/src/loaders/model_config.cpp
+++ b/src/cpp/src/loaders/model_config.cpp
@@ -178,6 +178,51 @@ std::vector<std::string> extract_json_string_array(const std::string& json, cons
     return result;
 }
 
+std::string extract_json_object(const std::string& json, const std::string& key) {
+    std::string search = "\"" + key + "\"";
+    auto pos = json.find(search);
+    if (pos == std::string::npos) return "";
+
+    pos = json.find(":", pos);
+    if (pos == std::string::npos) return "";
+
+    pos = json.find("{", pos);
+    if (pos == std::string::npos) return "";
+
+    size_t start = pos;
+    int depth = 0;
+    bool in_string = false;
+    bool escape = false;
+
+    for (size_t i = pos; i < json.size(); ++i) {
+        char c = json[i];
+        if (in_string) {
+            if (escape) {
+                escape = false;
+            } else if (c == '\\') {
+                escape = true;
+            } else if (c == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if (c == '"') {
+            in_string = true;
+            continue;
+        }
+        if (c == '{') {
+            ++depth;
+        } else if (c == '}') {
+            --depth;
+            if (depth == 0) {
+                return json.substr(start, i - start + 1);
+            }
+        }
+    }
+    return "";
+}
+
 }  // namespace
 
 ModelConfig ModelConfig::from_gguf(const std::map<std::string, GGUFMetaData>& meta) {
@@ -252,6 +297,8 @@ ModelConfig ModelConfig::from_hf_json(const std::filesystem::path& config_path) 
         config.architecture = "qwen3_next";
     } else if (config.model_type == "qwen3_moe") {
         config.architecture = "qwen3_moe";
+    } else if (config.model_type == "qwen3_asr_audio_encoder") {
+        config.architecture = "qwen3_asr_audio_encoder";
     }
     
     // Also check model_type for SmolLM3
@@ -263,31 +310,79 @@ ModelConfig ModelConfig::from_hf_json(const std::filesystem::path& config_path) 
         }
     }
     
+    std::string dims_json = json;
+
+    // Qwen3-ASR stores LM dimensions in thinker_config.text_config.
+    if (config.model_type == "qwen3_asr") {
+        config.architecture = "qwen3_asr";
+        auto thinker_json = extract_json_object(json, "thinker_config");
+        if (!thinker_json.empty()) {
+            auto text_json = extract_json_object(thinker_json, "text_config");
+            if (!text_json.empty()) {
+                dims_json = text_json;
+            }
+
+            auto audio_json = extract_json_object(thinker_json, "audio_config");
+            if (!audio_json.empty()) {
+                config.audio_num_mel_bins = extract_json_int(audio_json, "num_mel_bins", 0);
+                config.audio_hidden_size = extract_json_int(audio_json, "d_model", 0);
+                config.audio_intermediate_size = extract_json_int(audio_json, "encoder_ffn_dim", 0);
+                config.audio_num_hidden_layers = extract_json_int(audio_json, "encoder_layers", 0);
+                config.audio_num_attention_heads = extract_json_int(audio_json, "encoder_attention_heads", 0);
+                config.audio_max_position_embeddings = extract_json_int(audio_json, "max_source_positions", 0);
+                config.audio_downsample_hidden_size = extract_json_int(audio_json, "downsample_hidden_size", 0);
+                config.audio_output_dim = extract_json_int(audio_json, "output_dim", 0);
+                config.audio_hidden_act = extract_json_string(audio_json, "activation_function");
+            }
+        }
+    } else if (config.model_type == "qwen3_asr_audio_encoder") {
+        // Audio encoder config uses different field names.
+        // Map to unified ModelConfig dimensions:
+        // hidden_size <- d_model
+        // intermediate_size <- encoder_ffn_dim
+        // num_hidden_layers <- encoder_layers
+        // num_attention_heads <- encoder_attention_heads
+        config.hidden_size = extract_json_int(json, "d_model");
+        config.intermediate_size = extract_json_int(json, "encoder_ffn_dim");
+        config.num_hidden_layers = extract_json_int(json, "encoder_layers");
+        config.num_attention_heads = extract_json_int(json, "encoder_attention_heads");
+        config.num_key_value_heads = config.num_attention_heads;
+        config.head_dim = (config.hidden_size > 0 && config.num_attention_heads > 0)
+            ? (config.hidden_size / config.num_attention_heads)
+            : 0;
+        config.max_position_embeddings = extract_json_int(json, "max_source_positions", 1500);
+        config.hidden_act = extract_json_string(json, "activation_function");
+        if (config.hidden_act.empty()) {
+            config.hidden_act = "gelu";
+        }
+        return config;
+    }
+
     // Dimensions
-    config.hidden_size = extract_json_int(json, "hidden_size");
-    config.intermediate_size = extract_json_int(json, "intermediate_size");
-    config.num_hidden_layers = extract_json_int(json, "num_hidden_layers");
-    config.num_attention_heads = extract_json_int(json, "num_attention_heads");
-    config.num_key_value_heads = extract_json_int(json, "num_key_value_heads", config.num_attention_heads);
-    config.head_dim = extract_json_int(json, "head_dim", 0);
-    config.vocab_size = extract_json_int(json, "vocab_size");
-    config.max_position_embeddings = extract_json_int(json, "max_position_embeddings");
+    config.hidden_size = extract_json_int(dims_json, "hidden_size");
+    config.intermediate_size = extract_json_int(dims_json, "intermediate_size");
+    config.num_hidden_layers = extract_json_int(dims_json, "num_hidden_layers");
+    config.num_attention_heads = extract_json_int(dims_json, "num_attention_heads");
+    config.num_key_value_heads = extract_json_int(dims_json, "num_key_value_heads", config.num_attention_heads);
+    config.head_dim = extract_json_int(dims_json, "head_dim", 0);
+    config.vocab_size = extract_json_int(dims_json, "vocab_size");
+    config.max_position_embeddings = extract_json_int(dims_json, "max_position_embeddings");
 
     // DFlash-specific
     config.block_size = extract_json_int(json, "block_size", 0);
     config.num_target_layers = extract_json_int(json, "num_target_layers", 0);
     
     // Normalization
-    config.rms_norm_eps = extract_json_float(json, "rms_norm_eps", 1e-6f);
+    config.rms_norm_eps = extract_json_float(dims_json, "rms_norm_eps", 1e-6f);
     
     // RoPE
-    config.rope_theta = extract_json_float(json, "rope_theta", 10000.0f);
+    config.rope_theta = extract_json_float(dims_json, "rope_theta", 10000.0f);
     
     // Other
-    config.tie_word_embeddings = extract_json_bool(json, "tie_word_embeddings", false);
-    config.attention_bias = extract_json_bool(json, "attention_bias", false);
-    config.mlp_bias = extract_json_bool(json, "mlp_bias", false);
-    config.hidden_act = extract_json_string(json, "hidden_act");
+    config.tie_word_embeddings = extract_json_bool(dims_json, "tie_word_embeddings", false);
+    config.attention_bias = extract_json_bool(dims_json, "attention_bias", false);
+    config.mlp_bias = extract_json_bool(dims_json, "mlp_bias", false);
+    config.hidden_act = extract_json_string(dims_json, "hidden_act");
     if (config.hidden_act.empty()) {
         config.hidden_act = "silu";
     }

--- a/src/cpp/src/loaders/model_config.hpp
+++ b/src/cpp/src/loaders/model_config.hpp
@@ -173,6 +173,35 @@ struct ModelConfig {
 
     /// Optional list of dense MLP-only layer indices
     std::vector<int32_t> mlp_only_layers;
+
+    // ========== Qwen3-ASR nested audio_config ==========
+
+    /// Audio encoder mel bins (thinker_config.audio_config.num_mel_bins)
+    int32_t audio_num_mel_bins = 0;
+
+    /// Audio encoder hidden size (thinker_config.audio_config.d_model)
+    int32_t audio_hidden_size = 0;
+
+    /// Audio encoder FFN size (thinker_config.audio_config.encoder_ffn_dim)
+    int32_t audio_intermediate_size = 0;
+
+    /// Audio encoder number of layers (thinker_config.audio_config.encoder_layers)
+    int32_t audio_num_hidden_layers = 0;
+
+    /// Audio encoder attention heads (thinker_config.audio_config.encoder_attention_heads)
+    int32_t audio_num_attention_heads = 0;
+
+    /// Audio encoder max source positions (thinker_config.audio_config.max_source_positions)
+    int32_t audio_max_position_embeddings = 0;
+
+    /// Audio encoder downsample hidden size (thinker_config.audio_config.downsample_hidden_size)
+    int32_t audio_downsample_hidden_size = 0;
+
+    /// Audio encoder output embedding size (thinker_config.audio_config.output_dim)
+    int32_t audio_output_dim = 0;
+
+    /// Audio encoder activation (thinker_config.audio_config.activation_function)
+    std::string audio_hidden_act;
     
     // ========== Quantization ==========
     

--- a/src/cpp/src/modeling/models/qwen3/modeling_qwen3.cpp
+++ b/src/cpp/src/modeling/models/qwen3/modeling_qwen3.cpp
@@ -61,10 +61,12 @@ Qwen3Attention::Qwen3Attention(BuilderContext& ctx,
     v_proj_param_ = &register_parameter("v_proj.weight");
     o_proj_param_ = &register_parameter("o_proj.weight");
 
-    q_bias_param_ = &register_parameter("q_proj.bias");
-    k_bias_param_ = &register_parameter("k_proj.bias");
-    v_bias_param_ = &register_parameter("v_proj.bias");
-    o_bias_param_ = &register_parameter("o_proj.bias");
+    if (cfg.attention_bias) {
+        q_bias_param_ = &register_parameter("q_proj.bias");
+        k_bias_param_ = &register_parameter("k_proj.bias");
+        v_bias_param_ = &register_parameter("v_proj.bias");
+        o_bias_param_ = &register_parameter("o_proj.bias");
+    }
 }
 
 const Tensor& Qwen3Attention::q_proj_weight() const {
@@ -317,6 +319,25 @@ Tensor Qwen3Model::forward(const Tensor& input_ids, const Tensor& position_ids, 
     return norm_.forward(hidden_states);
 }
 
+Tensor Qwen3Model::forward_embeds(const Tensor& inputs_embeds,
+                                  const Tensor& position_ids,
+                                  const Tensor& beam_idx,
+                                  const Tensor& attention_mask) {
+    auto hidden_states = inputs_embeds;
+    auto* policy = &ctx().op_policy();
+    auto cos_sin = ops::llm::rope_cos_sin(position_ids, head_dim_, rope_theta_, policy);
+    std::optional<Tensor> residual;
+    for (auto& layer : layers_) {
+        auto layer_out = layer.forward(hidden_states, beam_idx, cos_sin.first, cos_sin.second, attention_mask, residual);
+        hidden_states = layer_out.first;
+        residual = layer_out.second;
+    }
+    if (residual) {
+        return norm_.forward(hidden_states, *residual).first;
+    }
+    return norm_.forward(hidden_states);
+}
+
 std::pair<Tensor, Tensor> Qwen3Model::forward_with_penultimate(const Tensor& input_ids,
                                                                const Tensor& position_ids,
                                                                const Tensor& beam_idx) {
@@ -492,6 +513,14 @@ Tensor Qwen3ForCausalLM::forward(const Tensor& input_ids,
                                  const Tensor& beam_idx,
                                  const Tensor& attention_mask) {
     auto hidden = model_.forward(input_ids, position_ids, beam_idx, attention_mask);
+    return lm_head_.forward(hidden);
+}
+
+Tensor Qwen3ForCausalLM::forward_embeds(const Tensor& inputs_embeds,
+                                        const Tensor& position_ids,
+                                        const Tensor& beam_idx,
+                                        const Tensor& attention_mask) {
+    auto hidden = model_.forward_embeds(inputs_embeds, position_ids, beam_idx, attention_mask);
     return lm_head_.forward(hidden);
 }
 

--- a/src/cpp/src/modeling/models/qwen3/modeling_qwen3.hpp
+++ b/src/cpp/src/modeling/models/qwen3/modeling_qwen3.hpp
@@ -154,6 +154,10 @@ public:
     Tensor forward_no_cache(const Tensor& input_ids,
                             const Tensor& position_ids,
                             const Tensor& attention_mask);
+    Tensor forward_embeds(const Tensor& inputs_embeds,
+                          const Tensor& position_ids,
+                          const Tensor& beam_idx,
+                          const Tensor& attention_mask);
     std::pair<Tensor, Tensor> forward_with_penultimate_no_cache(const Tensor& input_ids,
                                                                 const Tensor& position_ids,
                                                                 const Tensor& attention_mask);
@@ -183,6 +187,10 @@ public:
                    const Tensor& position_ids,
                    const Tensor& beam_idx,
                    const Tensor& attention_mask);
+    Tensor forward_embeds(const Tensor& inputs_embeds,
+                          const Tensor& position_ids,
+                          const Tensor& beam_idx,
+                          const Tensor& attention_mask);
 
     Qwen3Model& model();
     LMHead& lm_head();

--- a/src/cpp/src/modeling/models/qwen3_asr/modeling_qwen3_asr.cpp
+++ b/src/cpp/src/modeling/models/qwen3_asr/modeling_qwen3_asr.cpp
@@ -1,0 +1,473 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "modeling/models/qwen3_asr/modeling_qwen3_asr.hpp"
+
+#include <cmath>
+#include <limits>
+
+#include <openvino/core/except.hpp>
+#include <openvino/opsets/opset13.hpp>
+
+#include "modeling/ops/llm.hpp"
+#include "modeling/ops/nn.hpp"
+#include "modeling/ops/ops.hpp"
+#include "modeling/ops/shape.hpp"
+#include "modeling/ops/tensor_ops.hpp"
+#include "modeling/weights/weight_loader.hpp"
+
+namespace {
+
+auto set_name = [](auto node, const std::string& name) {
+    node->output(0).set_names({name});
+    node->set_friendly_name(name);
+};
+
+ov::genai::modeling::Tensor normalize_asr_position_ids(const ov::genai::modeling::Tensor& position_ids) {
+    // vLLM Qwen3-ASR uses MRoPE-style position_ids with shape [3, B, S].
+    // Qwen3 text stack expects [B, S], so use the first plane.
+    return ov::genai::modeling::ops::slice(position_ids, 0, 1, 1, 0).squeeze(0);
+}
+
+ov::Tensor create_sinusoidal_position_embedding(size_t length, size_t channels, int64_t max_timescale = 10000) {
+    if (channels % 2 != 0) {
+        OPENVINO_THROW("Sinusoidal embedding channels must be even");
+    }
+    ov::Tensor table(ov::element::f32, ov::Shape{length, channels});
+    float* data = table.data<float>();
+
+    const size_t half = channels / 2;
+    const float log_inc = std::log(static_cast<float>(max_timescale)) / static_cast<float>(half - 1);
+    for (size_t pos = 0; pos < length; ++pos) {
+        for (size_t i = 0; i < half; ++i) {
+            const float inv = std::exp(-log_inc * static_cast<float>(i));
+            const float v = static_cast<float>(pos) * inv;
+            data[pos * channels + i] = std::sin(v);
+            data[pos * channels + half + i] = std::cos(v);
+        }
+    }
+    return table;
+}
+
+}  // namespace
+
+namespace ov {
+namespace genai {
+namespace modeling {
+namespace models {
+
+int64_t qwen3_asr_feat_extract_output_length(int64_t input_length) {
+    auto floor_div = [](int64_t a, int64_t b) -> int64_t {
+        if (b == 0) {
+            OPENVINO_THROW("Division by zero in qwen3_asr_feat_extract_output_length");
+        }
+        int64_t q = a / b;
+        int64_t r = a % b;
+        if (r != 0 && ((r > 0) != (b > 0))) {
+            --q;
+        }
+        return q;
+    };
+
+    const int64_t input_lengths_leave = input_length % 100;
+    const int64_t feat_lengths = floor_div(input_lengths_leave - 1, 2) + 1;
+    const int64_t output_lengths =
+        (floor_div((floor_div(feat_lengths - 1, 2) + 1 - 1), 2) + 1 + floor_div(input_length, 100) * 13);
+    return output_lengths;
+}
+
+namespace {
+
+Tensor compute_cnn_output_lengths(const Tensor& input_lengths) {
+    auto* ctx = input_lengths.context();
+    auto one = Tensor(ops::const_scalar(ctx, int64_t{1}), ctx);
+    auto two = Tensor(ops::const_scalar(ctx, int64_t{2}), ctx);
+
+    auto lengths = input_lengths.to(ov::element::i64);
+    for (int i = 0; i < 3; ++i) {
+        lengths = ((lengths - one) / two) + one;
+    }
+    return lengths;
+}
+
+Tensor build_valid_mask(const Tensor& lengths, const Tensor& sequence_tensor) {
+    auto* ctx = sequence_tensor.context();
+    auto seq_len = Tensor(shape::dim(sequence_tensor, 1), ctx).squeeze(0);
+    auto idx = ops::range(seq_len, 0, 1, ov::element::i64).unsqueeze(0);  // [1, T]
+    auto one = Tensor(ops::const_scalar(ctx, int64_t{1}), ctx);
+    auto len_minus_one = (lengths.to(ov::element::i64) - one).unsqueeze(1);  // [B, 1]
+    return ops::less_equal(idx, len_minus_one);  // [B, T]
+}
+
+class Qwen3ASRAudioAttentionLite : public Module {
+public:
+    Qwen3ASRAudioAttentionLite(BuilderContext& ctx,
+                               const std::string& name,
+                               const Qwen3ASRAudioConfig& cfg,
+                               Module* parent = nullptr)
+        : Module(name, ctx, parent),
+          num_heads_(cfg.encoder_attention_heads),
+          head_dim_(cfg.d_model / cfg.encoder_attention_heads),
+          scale_(1.0f / std::sqrt(static_cast<float>(head_dim_))) {
+        q_proj_w_ = &register_parameter("q_proj.weight");
+        q_proj_b_ = &register_parameter("q_proj.bias");
+        k_proj_w_ = &register_parameter("k_proj.weight");
+        k_proj_b_ = &register_parameter("k_proj.bias");
+        v_proj_w_ = &register_parameter("v_proj.weight");
+        v_proj_b_ = &register_parameter("v_proj.bias");
+        out_proj_w_ = &register_parameter("out_proj.weight");
+        out_proj_b_ = &register_parameter("out_proj.bias");
+    }
+
+    Tensor forward(const Tensor& hidden_states, const Tensor& valid_mask) const {
+        auto* op_ctx = hidden_states.context();
+        auto q = ops::linear(hidden_states, q_proj_w_->value()) + q_proj_b_->value();
+        auto k = ops::linear(hidden_states, k_proj_w_->value()) + k_proj_b_->value();
+        auto v = ops::linear(hidden_states, v_proj_w_->value()) + v_proj_b_->value();
+
+        auto qh = q.reshape({0, 0, num_heads_, head_dim_}).permute({0, 2, 1, 3});
+        auto kh = k.reshape({0, 0, num_heads_, head_dim_}).permute({0, 2, 1, 3});
+        auto vh = v.reshape({0, 0, num_heads_, head_dim_}).permute({0, 2, 1, 3});
+
+        auto zero = Tensor(ops::const_scalar(op_ctx, 0.0f), op_ctx);
+        auto neg = Tensor(ops::const_scalar(op_ctx, -65504.0f), op_ctx);
+        auto pad_mask = ops::where(valid_mask, zero, neg).unsqueeze({1, 2});  // [B,1,1,T]
+
+        auto attn = ops::llm::sdpa(qh, kh, vh, scale_, 3, &pad_mask, false, &ctx().op_policy());
+        auto merged = attn.permute({0, 2, 1, 3}).reshape({0, 0, static_cast<int64_t>(num_heads_ * head_dim_)});
+        return ops::linear(merged, out_proj_w_->value()) + out_proj_b_->value();
+    }
+
+private:
+    int32_t num_heads_ = 0;
+    int32_t head_dim_ = 0;
+    float scale_ = 1.0f;
+
+    WeightParameter* q_proj_w_ = nullptr;
+    WeightParameter* q_proj_b_ = nullptr;
+    WeightParameter* k_proj_w_ = nullptr;
+    WeightParameter* k_proj_b_ = nullptr;
+    WeightParameter* v_proj_w_ = nullptr;
+    WeightParameter* v_proj_b_ = nullptr;
+    WeightParameter* out_proj_w_ = nullptr;
+    WeightParameter* out_proj_b_ = nullptr;
+};
+
+class Qwen3ASRAudioEncoderLayerLite : public Module {
+public:
+    Qwen3ASRAudioEncoderLayerLite(BuilderContext& ctx,
+                                  const std::string& name,
+                                  const Qwen3ASRAudioConfig& cfg,
+                                  Module* parent = nullptr)
+        : Module(name, ctx, parent),
+          self_attn_(ctx, "self_attn", cfg, this) {
+        ln1_w_ = &register_parameter("self_attn_layer_norm.weight");
+        ln1_b_ = &register_parameter("self_attn_layer_norm.bias");
+        fc1_w_ = &register_parameter("fc1.weight");
+        fc1_b_ = &register_parameter("fc1.bias");
+        fc2_w_ = &register_parameter("fc2.weight");
+        fc2_b_ = &register_parameter("fc2.bias");
+        ln2_w_ = &register_parameter("final_layer_norm.weight");
+        ln2_b_ = &register_parameter("final_layer_norm.bias");
+    }
+
+    Tensor forward(const Tensor& x, const Tensor& valid_mask, const std::string& activation) const {
+        auto norm1 = ops::nn::layer_norm(x, ln1_w_->value(), &ln1_b_->value(), 1e-5f, -1);
+        auto attn = self_attn_.forward(norm1, valid_mask);
+        auto h = x + attn;
+
+        auto norm2 = ops::nn::layer_norm(h, ln2_w_->value(), &ln2_b_->value(), 1e-5f, -1);
+        auto ff = ops::linear(norm2, fc1_w_->value()) + fc1_b_->value();
+        if (activation == "relu") {
+            ff = ops::nn::relu(ff);
+        } else {
+            ff = ops::nn::gelu(ff, true);
+        }
+        ff = ops::linear(ff, fc2_w_->value()) + fc2_b_->value();
+        h = h + ff;
+
+        auto keep = valid_mask.unsqueeze(2).to(h.dtype());
+        return h * keep;
+    }
+
+private:
+    Qwen3ASRAudioAttentionLite self_attn_;
+    WeightParameter* ln1_w_ = nullptr;
+    WeightParameter* ln1_b_ = nullptr;
+    WeightParameter* fc1_w_ = nullptr;
+    WeightParameter* fc1_b_ = nullptr;
+    WeightParameter* fc2_w_ = nullptr;
+    WeightParameter* fc2_b_ = nullptr;
+    WeightParameter* ln2_w_ = nullptr;
+    WeightParameter* ln2_b_ = nullptr;
+};
+
+class Qwen3ASRAudioEncoderLite : public Module {
+public:
+    Qwen3ASRAudioEncoderLite(BuilderContext& ctx, const Qwen3ASRAudioConfig& cfg, Module* parent = nullptr)
+        : Module("audio_tower", ctx, parent), cfg_(cfg) {
+        conv2d1_w_ = &register_parameter("conv2d1.weight");
+        conv2d1_b_ = &register_parameter("conv2d1.bias");
+        conv2d2_w_ = &register_parameter("conv2d2.weight");
+        conv2d2_b_ = &register_parameter("conv2d2.bias");
+        conv2d3_w_ = &register_parameter("conv2d3.weight");
+        conv2d3_b_ = &register_parameter("conv2d3.bias");
+        conv_out_w_ = &register_parameter("conv_out.weight");
+
+        ln_post_w_ = &register_parameter("ln_post.weight");
+        ln_post_b_ = &register_parameter("ln_post.bias");
+        proj1_w_ = &register_parameter("proj1.weight");
+        proj1_b_ = &register_parameter("proj1.bias");
+        proj2_w_ = &register_parameter("proj2.weight");
+        proj2_b_ = &register_parameter("proj2.bias");
+
+        layers_.reserve(static_cast<size_t>(cfg.encoder_layers));
+        for (int32_t i = 0; i < cfg.encoder_layers; ++i) {
+            layers_.emplace_back(ctx, "layers[" + std::to_string(i) + "]", cfg, this);
+        }
+
+        positional_const_ = ops::constant(
+            create_sinusoidal_position_embedding(static_cast<size_t>(cfg.max_source_positions),
+                                                 static_cast<size_t>(cfg.d_model)),
+            &ctx.op_context());
+    }
+
+    std::pair<Tensor, Tensor> forward(const Tensor& input_features, const Tensor& audio_feature_lengths) const {
+        // input_features: [B, mel, T]
+        auto x = input_features.unsqueeze(1);  // [B,1,mel,T]
+
+        x = ops::nn::gelu(ops::nn::conv2d(x, conv2d1_w_->value(), conv2d1_b_->value(), {2, 2}, {1, 1}, {1, 1}), true);
+        x = ops::nn::gelu(ops::nn::conv2d(x, conv2d2_w_->value(), conv2d2_b_->value(), {2, 2}, {1, 1}, {1, 1}), true);
+        x = ops::nn::gelu(ops::nn::conv2d(x, conv2d3_w_->value(), conv2d3_b_->value(), {2, 2}, {1, 1}, {1, 1}), true);
+
+        // [B,C,F,T] -> [B,T,C,F] -> [B,T,C*F]
+        x = x.permute({0, 3, 1, 2});
+        x = x.reshape({0, 0, -1});
+        x = ops::linear(x, conv_out_w_->value());
+
+        // Add sinusoidal positional embedding
+        auto* op_ctx = x.context();
+        auto t = Tensor(shape::dim(x, 1), op_ctx).squeeze(0);
+        auto pos_idx = ops::range(t, 0, 1, ov::element::i64);
+        auto pos = ops::gather(positional_const_, pos_idx, 0);  // [T, D]
+        auto pos_b = shape::broadcast_to(pos.unsqueeze(0), shape::make({shape::dim(x, 0), shape::dim(x, 1), shape::dim(x, 2)}));
+        x = x + pos_b.to(x.dtype());
+
+        auto cnn_lengths = compute_cnn_output_lengths(audio_feature_lengths);
+        auto valid_mask = build_valid_mask(cnn_lengths, x);  // [B, T]
+
+        x = x * valid_mask.unsqueeze(2).to(x.dtype());
+        for (const auto& layer : layers_) {
+            x = layer.forward(x, valid_mask, cfg_.activation_function);
+        }
+
+        x = ops::nn::layer_norm(x, ln_post_w_->value(), &ln_post_b_->value(), 1e-5f, -1);
+        x = ops::linear(x, proj1_w_->value()) + proj1_b_->value();
+        if (cfg_.activation_function == "relu") {
+            x = ops::nn::relu(x);
+        } else {
+            x = ops::nn::gelu(x, true);
+        }
+        x = ops::linear(x, proj2_w_->value()) + proj2_b_->value();
+        x = x * valid_mask.unsqueeze(2).to(x.dtype());
+        return {x, cnn_lengths};
+    }
+
+private:
+    Qwen3ASRAudioConfig cfg_;
+    std::vector<Qwen3ASRAudioEncoderLayerLite> layers_;
+    Tensor positional_const_;
+
+    WeightParameter* conv2d1_w_ = nullptr;
+    WeightParameter* conv2d1_b_ = nullptr;
+    WeightParameter* conv2d2_w_ = nullptr;
+    WeightParameter* conv2d2_b_ = nullptr;
+    WeightParameter* conv2d3_w_ = nullptr;
+    WeightParameter* conv2d3_b_ = nullptr;
+    WeightParameter* conv_out_w_ = nullptr;
+
+    WeightParameter* ln_post_w_ = nullptr;
+    WeightParameter* ln_post_b_ = nullptr;
+    WeightParameter* proj1_w_ = nullptr;
+    WeightParameter* proj1_b_ = nullptr;
+    WeightParameter* proj2_w_ = nullptr;
+    WeightParameter* proj2_b_ = nullptr;
+};
+
+}  // namespace
+
+std::shared_ptr<ov::Model> create_qwen3_asr_text_model(
+    const Qwen3ASRTextConfig& cfg,
+    ov::genai::modeling::weights::WeightSource& source,
+    ov::genai::modeling::weights::WeightFinalizer& finalizer,
+    bool use_inputs_embeds,
+    bool enable_audio_inputs) {
+    Qwen3DenseConfig dense_cfg;
+    dense_cfg.architecture = cfg.architecture;
+    dense_cfg.hidden_size = cfg.hidden_size;
+    dense_cfg.num_attention_heads = cfg.num_attention_heads;
+    dense_cfg.num_key_value_heads = cfg.num_key_value_heads > 0 ? cfg.num_key_value_heads : cfg.num_attention_heads;
+    dense_cfg.head_dim = cfg.head_dim;
+    dense_cfg.intermediate_size = cfg.intermediate_size;
+    dense_cfg.num_hidden_layers = cfg.num_hidden_layers;
+    dense_cfg.rms_norm_eps = cfg.rms_norm_eps;
+    dense_cfg.rope_theta = cfg.rope_theta;
+    dense_cfg.hidden_act = cfg.hidden_act;
+    dense_cfg.attention_bias = cfg.attention_bias;
+    dense_cfg.tie_word_embeddings = cfg.tie_word_embeddings;
+
+    BuilderContext ctx;
+    Qwen3ForCausalLM model(ctx, dense_cfg);
+
+    // Support raw HF ASR prefixes and vLLM-remapped prefixes.
+    model.packed_mapping().rules.push_back({"thinker.model.", "model.", 0});
+    model.packed_mapping().rules.push_back({"thinker.lm_head.", "lm_head.", 0});
+    model.packed_mapping().rules.push_back({"language_model.model.", "model.", 0});
+    model.packed_mapping().rules.push_back({"language_model.lm_head.", "lm_head.", 0});
+
+    ov::genai::modeling::weights::LoadOptions options;
+    options.allow_missing = false;
+    options.allow_unmatched = true;  // ASR checkpoints also contain audio tower weights.
+    options.report_missing = true;
+    options.report_unmatched = false;
+    (void)ov::genai::modeling::weights::load_model(model, source, finalizer, options);
+
+    auto attention_mask = ctx.parameter(Qwen3ASRTextIO::kAttentionMask, ov::element::i64, ov::PartialShape{-1, -1});
+    auto position_ids = ctx.parameter(Qwen3ASRTextIO::kPositionIds, ov::element::i64, ov::PartialShape{3, -1, -1});
+    auto beam_idx = ctx.parameter(Qwen3ASRTextIO::kBeamIdx, ov::element::i32, ov::PartialShape{-1});
+
+    const auto float_type = ov::element::f32;
+    Tensor input_ids;
+    Tensor inputs_embeds;
+    if (use_inputs_embeds) {
+        inputs_embeds =
+            ctx.parameter(Qwen3ASRTextIO::kInputsEmbeds, float_type, ov::PartialShape{-1, -1, cfg.hidden_size});
+    } else {
+        input_ids = ctx.parameter(Qwen3ASRTextIO::kInputIds, ov::element::i64, ov::PartialShape{-1, -1});
+        inputs_embeds = model.model().embed_tokens().forward(input_ids);
+    }
+
+    if (enable_audio_inputs) {
+        auto audio_embeds =
+            ctx.parameter(Qwen3ASRTextIO::kAudioEmbeds, float_type, ov::PartialShape{-1, -1, cfg.hidden_size});
+        auto audio_pos_mask =
+            ctx.parameter(Qwen3ASRTextIO::kAudioPosMask, ov::element::boolean, ov::PartialShape{-1, -1});
+        inputs_embeds = ops::tensor::masked_scatter(inputs_embeds, audio_pos_mask.unsqueeze(2), audio_embeds.to(inputs_embeds.dtype()));
+    }
+
+    auto position_ids_2d = normalize_asr_position_ids(position_ids);
+    auto logits = model.forward_embeds(inputs_embeds, position_ids_2d, beam_idx, attention_mask);
+
+    auto result = std::make_shared<ov::op::v0::Result>(logits.output());
+    set_name(result, Qwen3ASRTextIO::kLogits);
+    return ctx.build_model({result->output(0)});
+}
+
+std::shared_ptr<ov::Model> create_qwen3_asr_audio_encoder_model(
+    const Qwen3ASRAudioConfig& cfg,
+    ov::genai::modeling::weights::WeightSource& source,
+    ov::genai::modeling::weights::WeightFinalizer& finalizer) {
+    BuilderContext ctx;
+    Qwen3ASRAudioEncoderLite model(ctx, cfg);
+
+    for (int32_t i = 0; i < cfg.encoder_layers; ++i) {
+        const std::string idx = std::to_string(i);
+        model.packed_mapping().rules.push_back({"thinker.audio_tower.layers." + idx + ".", "audio_tower.layers[" + idx + "].", 0});
+        model.packed_mapping().rules.push_back({"audio_tower.layers." + idx + ".", "audio_tower.layers[" + idx + "].", 0});
+    }
+    model.packed_mapping().rules.push_back({"thinker.audio_tower.", "audio_tower.", 0});
+
+    ov::genai::modeling::weights::LoadOptions options;
+    options.allow_missing = false;
+    options.allow_unmatched = true;
+    options.report_missing = true;
+    options.report_unmatched = false;
+    (void)ov::genai::modeling::weights::load_model(model, source, finalizer, options);
+
+    auto input_audio_features =
+        ctx.parameter(Qwen3ASRAudioIO::kInputAudioFeatures, ov::element::f32, ov::PartialShape{-1, -1, -1});
+    auto audio_feature_lengths =
+        ctx.parameter(Qwen3ASRAudioIO::kAudioFeatureLengths, ov::element::i64, ov::PartialShape{-1});
+
+    auto out = model.forward(input_audio_features, audio_feature_lengths);
+
+    auto embeds_res = std::make_shared<ov::op::v0::Result>(out.first.output());
+    set_name(embeds_res, Qwen3ASRAudioIO::kAudioEmbeds);
+    auto lens_res = std::make_shared<ov::op::v0::Result>(out.second.output());
+    set_name(lens_res, Qwen3ASRAudioIO::kAudioOutputLengths);
+    return ctx.build_model({embeds_res->output(0), lens_res->output(0)});
+}
+
+}  // namespace models
+}  // namespace modeling
+}  // namespace genai
+}  // namespace ov
+
+// ============================================================================
+// Model Builder Registration
+// ============================================================================
+
+#include "loaders/model_builder.hpp"
+
+namespace {
+
+std::shared_ptr<ov::Model> build_qwen3_asr_model(
+    const ov::genai::loaders::ModelConfig& config,
+    ov::genai::modeling::weights::WeightSource& weight_source,
+    ov::genai::modeling::weights::WeightFinalizer& weight_finalizer) {
+    using namespace ov::genai::modeling::models;
+
+    if (config.hidden_size <= 0 || config.num_hidden_layers <= 0 || config.num_attention_heads <= 0 ||
+        config.intermediate_size <= 0) {
+        OPENVINO_THROW("Invalid Qwen3-ASR config: hidden_size/num_hidden_layers/num_attention_heads/intermediate_size must be > 0");
+    }
+
+    Qwen3ASRTextConfig cfg;
+    cfg.architecture = "qwen3_asr";
+    cfg.vocab_size = config.vocab_size;
+    cfg.hidden_size = config.hidden_size;
+    cfg.intermediate_size = config.intermediate_size;
+    cfg.num_hidden_layers = config.num_hidden_layers;
+    cfg.num_attention_heads = config.num_attention_heads;
+    cfg.num_key_value_heads = config.num_key_value_heads > 0 ? config.num_key_value_heads : config.num_attention_heads;
+    cfg.head_dim = config.head_dim > 0 ? config.head_dim : (config.hidden_size / config.num_attention_heads);
+    cfg.max_position_embeddings = config.max_position_embeddings;
+    cfg.rms_norm_eps = config.rms_norm_eps;
+    cfg.rope_theta = config.rope_theta;
+    cfg.hidden_act = config.hidden_act;
+    cfg.attention_bias = config.attention_bias;
+    cfg.tie_word_embeddings = config.tie_word_embeddings;
+
+    return create_qwen3_asr_text_model(cfg, weight_source, weight_finalizer, false, true);
+}
+
+std::shared_ptr<ov::Model> build_qwen3_asr_audio_encoder_model(
+    const ov::genai::loaders::ModelConfig& config,
+    ov::genai::modeling::weights::WeightSource& weight_source,
+    ov::genai::modeling::weights::WeightFinalizer& weight_finalizer) {
+    using namespace ov::genai::modeling::models;
+
+    Qwen3ASRAudioConfig cfg;
+    cfg.architecture = "qwen3_asr_audio_encoder";
+    cfg.d_model = config.hidden_size > 0 ? config.hidden_size : 1280;
+    cfg.encoder_layers = config.num_hidden_layers > 0 ? config.num_hidden_layers : 32;
+    cfg.encoder_attention_heads = config.num_attention_heads > 0 ? config.num_attention_heads : 20;
+    cfg.encoder_ffn_dim = config.intermediate_size > 0 ? config.intermediate_size : 5120;
+    cfg.max_source_positions = config.max_position_embeddings > 0 ? config.max_position_embeddings : 1500;
+    cfg.num_mel_bins = 128;
+    cfg.downsample_hidden_size = 480;
+    cfg.output_dim = 3584;
+    cfg.activation_function = config.hidden_act.empty() ? "gelu" : config.hidden_act;
+    return create_qwen3_asr_audio_encoder_model(cfg, weight_source, weight_finalizer);
+}
+
+static bool _registered_qwen3_asr = []() {
+    ov::genai::loaders::ModelBuilder::instance().register_architecture("qwen3_asr", build_qwen3_asr_model);
+    ov::genai::loaders::ModelBuilder::instance().register_architecture("qwen3asr", build_qwen3_asr_model);
+    ov::genai::loaders::ModelBuilder::instance().register_architecture("qwen3_asr_text", build_qwen3_asr_model);
+    ov::genai::loaders::ModelBuilder::instance().register_architecture("qwen3_asr_audio_encoder", build_qwen3_asr_audio_encoder_model);
+    ov::genai::loaders::ModelBuilder::instance().register_architecture("qwen3asraudioencoder", build_qwen3_asr_audio_encoder_model);
+    return true;
+}();
+
+}  // namespace

--- a/src/cpp/src/modeling/models/qwen3_asr/modeling_qwen3_asr.cpp
+++ b/src/cpp/src/modeling/models/qwen3_asr/modeling_qwen3_asr.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <limits>
 
+#include <openvino/openvino.hpp>
 #include <openvino/core/except.hpp>
 #include <openvino/opsets/opset13.hpp>
 
@@ -360,7 +361,13 @@ std::shared_ptr<ov::Model> create_qwen3_asr_text_model(
 
     auto result = std::make_shared<ov::op::v0::Result>(logits.output());
     set_name(result, Qwen3ASRTextIO::kLogits);
-    return ctx.build_model({result->output(0)});
+    auto ov_model = ctx.build_model({result->output(0)});
+
+    // Match qwen3 runtime options to reduce KV-cache bandwidth pressure during decode.
+    ov_model->set_rt_info(ov::element::f16, {"runtime_options", ov::hint::kv_cache_precision.name()});
+    ov_model->set_rt_info(8.0f, {"runtime_options", ov::hint::activations_scale_factor.name()});
+
+    return ov_model;
 }
 
 std::shared_ptr<ov::Model> create_qwen3_asr_audio_encoder_model(

--- a/src/cpp/src/modeling/models/qwen3_asr/modeling_qwen3_asr.hpp
+++ b/src/cpp/src/modeling/models/qwen3_asr/modeling_qwen3_asr.hpp
@@ -1,0 +1,100 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace ov {
+class Model;
+}  // namespace ov
+
+namespace ov {
+namespace genai {
+namespace modeling {
+namespace weights {
+class WeightFinalizer;
+class WeightSource;
+}  // namespace weights
+}  // namespace modeling
+}  // namespace genai
+}  // namespace ov
+
+#include "modeling/models/qwen3/modeling_qwen3.hpp"
+
+namespace ov {
+namespace genai {
+namespace modeling {
+namespace models {
+
+struct Qwen3ASRTextConfig {
+    std::string architecture = "qwen3_asr";
+    int32_t vocab_size = 0;
+    int32_t hidden_size = 0;
+    int32_t intermediate_size = 0;
+    int32_t num_hidden_layers = 0;
+    int32_t num_attention_heads = 0;
+    int32_t num_key_value_heads = 0;
+    int32_t head_dim = 0;
+    int32_t max_position_embeddings = 0;
+
+    float rms_norm_eps = 1e-6f;
+    float rope_theta = 5000000.0f;
+
+    std::string hidden_act = "silu";
+    bool attention_bias = false;
+    bool tie_word_embeddings = false;
+};
+
+struct Qwen3ASRAudioConfig {
+    std::string architecture = "qwen3_asr_audio_encoder";
+    int32_t num_mel_bins = 128;
+    int32_t d_model = 1280;
+    int32_t encoder_layers = 32;
+    int32_t encoder_attention_heads = 20;
+    int32_t encoder_ffn_dim = 5120;
+    int32_t output_dim = 3584;
+    int32_t max_source_positions = 1500;
+    int32_t downsample_hidden_size = 480;
+    std::string activation_function = "gelu";
+};
+
+struct Qwen3ASRTextIO {
+    static constexpr const char* kInputIds = "input_ids";
+    static constexpr const char* kInputsEmbeds = "inputs_embeds";
+    static constexpr const char* kAttentionMask = "attention_mask";
+    static constexpr const char* kPositionIds = "position_ids";
+    static constexpr const char* kBeamIdx = "beam_idx";
+    static constexpr const char* kAudioEmbeds = "audio_embeds";
+    static constexpr const char* kAudioPosMask = "audio_pos_mask";
+    static constexpr const char* kLogits = "logits";
+};
+
+struct Qwen3ASRAudioIO {
+    static constexpr const char* kInputAudioFeatures = "input_audio_features";
+    static constexpr const char* kAudioFeatureLengths = "audio_feature_lengths";
+    static constexpr const char* kAudioEmbeds = "audio_embeds";
+    static constexpr const char* kAudioOutputLengths = "audio_output_lengths";
+};
+
+// Same formula used by vLLM Qwen3-ASR multimodal processor.
+int64_t qwen3_asr_feat_extract_output_length(int64_t input_length);
+
+std::shared_ptr<ov::Model> create_qwen3_asr_text_model(
+    const Qwen3ASRTextConfig& cfg,
+    ov::genai::modeling::weights::WeightSource& source,
+    ov::genai::modeling::weights::WeightFinalizer& finalizer,
+    bool use_inputs_embeds = false,
+    bool enable_audio_inputs = true);
+
+std::shared_ptr<ov::Model> create_qwen3_asr_audio_encoder_model(
+    const Qwen3ASRAudioConfig& cfg,
+    ov::genai::modeling::weights::WeightSource& source,
+    ov::genai::modeling::weights::WeightFinalizer& finalizer);
+
+}  // namespace models
+}  // namespace modeling
+}  // namespace genai
+}  // namespace ov

--- a/src/cpp/src/modeling/samples/CMakeLists.txt
+++ b/src/cpp/src/modeling/samples/CMakeLists.txt
@@ -246,3 +246,32 @@ add_custom_command(TARGET modeling_qwen3_tts POST_BUILD
 set_target_properties(modeling_qwen3_tts PROPERTIES
     # Ensure out of box LC_RPATH on macOS with SIP
     INSTALL_RPATH_USE_LINK_PATH ON)
+
+# Qwen3-ASR sample
+add_executable(modeling_qwen3_asr
+    modeling_qwen3_asr.cpp
+    $<TARGET_OBJECTS:openvino_genai_obj>)
+
+target_include_directories(modeling_qwen3_asr PRIVATE
+    "${CMAKE_BINARY_DIR}"
+    "${OpenVINOGenAI_SOURCE_DIR}/src/cpp/src"
+    "${OpenVINOGenAI_SOURCE_DIR}/openvino/thirdparty/json/nlohmann_json/include"
+    $<TARGET_PROPERTY:openvino::genai,INTERFACE_INCLUDE_DIRECTORIES>)
+
+target_link_libraries(modeling_qwen3_asr PRIVATE
+    $<TARGET_PROPERTY:openvino_genai_obj,LINK_LIBRARIES>)
+
+target_compile_definitions(modeling_qwen3_asr PRIVATE
+    openvino_genai_EXPORTS)
+
+add_dependencies(modeling_qwen3_asr openvino_genai)
+
+add_custom_command(TARGET modeling_qwen3_asr POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "$<TARGET_FILE_DIR:openvino_genai>/${tokenizers_dll_name}"
+            "$<TARGET_FILE_DIR:modeling_qwen3_asr>"
+    VERBATIM)
+
+set_target_properties(modeling_qwen3_asr PROPERTIES
+    # Ensure out of box LC_RPATH on macOS with SIP
+    INSTALL_RPATH_USE_LINK_PATH ON)

--- a/src/cpp/src/modeling/samples/modeling_qwen3_asr.cpp
+++ b/src/cpp/src/modeling/samples/modeling_qwen3_asr.cpp
@@ -610,11 +610,6 @@ bool is_language_tag_token(const std::string& token) {
     return true;
 }
 
-bool is_text_stop_token(const std::string& token) {
-    // Common end markers used by Qwen-family chat/tokenizers.
-    return token == "<|endoftext|>" || token == "<|im_end|>" || token == "<|eot_id|>";
-}
-
 std::string detect_language_from_tokens(ov::genai::Tokenizer& tokenizer, const std::vector<int64_t>& generated_ids) {
     for (size_t i = 0; i < generated_ids.size() && i < 8; ++i) {
         const std::string token = tokenizer.decode({generated_ids[i]}, {ov::genai::skip_special_tokens(false)});
@@ -1047,6 +1042,11 @@ int main(int argc, char* argv[]) try {
     const int64_t excl_token_id = find_token_id(vocab, {"!"}, -1);
     const int64_t qmark_token_id = find_token_id(vocab, {"?"}, -1);
 
+    std::unordered_set<int64_t> stop_token_ids;
+    add_token_if_found(vocab, "<|endoftext|>", stop_token_ids);
+    add_token_if_found(vocab, "<|im_end|>", stop_token_ids);
+    add_token_if_found(vocab, "<|eot_id|>", stop_token_ids);
+
     ov::Shape logits_shape;
     double ttft_ms = 0.0;
     double decode_ms = 0.0;
@@ -1095,15 +1095,27 @@ int main(int argc, char* argv[]) try {
     };
 
     text_request.reset_state();
+    ov::Tensor beam_idx = make_i32({batch}, 0);
     text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kBeamIdx,
-                            make_i32({batch}, 0));
+                            beam_idx);
+
+    const size_t max_total_seq_len = prompt_token_size + static_cast<size_t>(max_new_tokens);
+    std::vector<int64_t> attention_mask_storage(max_total_seq_len, 1);
+    auto make_attention_mask_view = [&](size_t seq_len) -> ov::Tensor {
+        if (seq_len == 0 || seq_len > max_total_seq_len) {
+            throw std::runtime_error("Invalid seq_len for attention mask view");
+        }
+        return ov::Tensor(ov::element::i64,
+                          ov::Shape{batch, seq_len},
+                          attention_mask_storage.data());
+    };
 
     // Prefill: run full prompt once to initialize KV cache.
     const size_t prompt_seq_len = input_ids.size();
     text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kInputIds,
                             make_i64_from_vector(input_ids));
     text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kAttentionMask,
-                            make_i64({batch, prompt_seq_len}, 1));
+                            make_attention_mask_view(prompt_seq_len));
     text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kPositionIds,
                             make_position_ids_3d(batch, prompt_seq_len));
     if (!text_only) {
@@ -1123,8 +1135,8 @@ int main(int argc, char* argv[]) try {
     auto process_logits_and_append = [&](const ov::Tensor& logits) -> bool {
         logits_shape = logits.get_shape();
         const int64_t next_token_id = argmax_last_token_id_excluding(logits, excluded_decode_ids);
-        const std::string next_token_text = tokenizer.decode({next_token_id}, {ov::genai::skip_special_tokens(false)});
-        if ((eos_token_id >= 0 && next_token_id == eos_token_id) || is_text_stop_token(next_token_text)) {
+        if ((eos_token_id >= 0 && next_token_id == eos_token_id) ||
+            (stop_token_ids.find(next_token_id) != stop_token_ids.end())) {
             return true;
         }
         generated_ids.push_back(next_token_id);
@@ -1154,7 +1166,7 @@ int main(int argc, char* argv[]) try {
         text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kInputIds,
                                 one_token_ids);
         text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kAttentionMask,
-                                make_i64({batch, total_seq_len}, 1));
+                                make_attention_mask_view(total_seq_len));
         text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kPositionIds,
                                 one_token_pos_ids);
         if (!text_only) {

--- a/src/cpp/src/modeling/samples/modeling_qwen3_asr.cpp
+++ b/src/cpp/src/modeling/samples/modeling_qwen3_asr.cpp
@@ -1,0 +1,1248 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <regex>
+#include <unordered_map>
+#include <unordered_set>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <openvino/openvino.hpp>
+
+#include "loaders/model_config.hpp"
+#include "modeling/models/qwen3_asr/modeling_qwen3_asr.hpp"
+#include "modeling/weights/quantization_config.hpp"
+#include "openvino/genai/tokenizer.hpp"
+#include "safetensors_utils/safetensors_loader.hpp"
+#include "safetensors_utils/safetensors_weight_finalizer.hpp"
+#include "safetensors_utils/safetensors_weight_source.hpp"
+#include "whisper/feature_extractor.hpp"
+
+namespace {
+
+std::string trim_copy(const std::string& s);
+std::string normalize_language_name(const std::string& raw);
+
+bool has_ir_model_pair(const std::filesystem::path& xml_path, const std::filesystem::path& bin_path) {
+    return std::filesystem::exists(xml_path) && std::filesystem::is_regular_file(xml_path) &&
+           std::filesystem::exists(bin_path) && std::filesystem::is_regular_file(bin_path);
+}
+
+bool model_has_input_named(const std::shared_ptr<ov::Model>& model, const char* name) {
+    for (const auto& input : model->inputs()) {
+        for (const auto& input_name : input.get_names()) {
+            if (input_name == name) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool text_model_cache_supports_mode(const std::shared_ptr<ov::Model>& model, bool expect_audio_inputs) {
+    const bool has_audio_embeds =
+        model_has_input_named(model, ov::genai::modeling::models::Qwen3ASRTextIO::kAudioEmbeds);
+    const bool has_audio_pos_mask =
+        model_has_input_named(model, ov::genai::modeling::models::Qwen3ASRTextIO::kAudioPosMask);
+    const bool has_audio_inputs = has_audio_embeds || has_audio_pos_mask;
+    return has_audio_inputs == expect_audio_inputs;
+}
+
+double elapsed_ms(const std::chrono::steady_clock::time_point& start,
+                  const std::chrono::steady_clock::time_point& end) {
+    return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+void print_usage(const char* argv0) {
+    std::cout
+        << "Qwen3-ASR modeling sample\n"
+        << "Usage:\n"
+        << "  " << argv0
+        << " <TEXT_MODEL_DIR> [AUDIO_MODEL_DIR] [DEVICE] [--wav <AUDIO.wav>] [--device <DEVICE>] [--max_new_tokens <N>] [--text-only] [--prompt <TEXT>]\n\n"
+        << "Examples:\n"
+        << "  " << argv0 << " C:/models/Qwen3-ASR\n"
+        << "  " << argv0 << " C:/models/Qwen3-ASR/text C:/models/Qwen3-ASR/audio GPU\n"
+        << "  " << argv0 << " C:/models/Qwen3-ASR --wav C:/audio/test.wav --device GPU --max_new_tokens 128\n"
+        << "  " << argv0 << " C:/models/Qwen3-ASR --text-only --prompt \"Summarize this sentence.\" --device GPU\n"
+        << "  " << argv0 << " C:/models/Qwen3-ASR --cached-model\n\n"
+        << "Options:\n"
+        << "  --cached-model (or --cache-model)  Serialize built IR to model directory before inference\n\n"
+        << "In-flight quantization (optional, env-based):\n"
+        << "  OV_GENAI_INFLIGHT_QUANT_MODE\n"
+        << "  OV_GENAI_INFLIGHT_QUANT_GROUP_SIZE\n"
+        << "  OV_GENAI_INFLIGHT_QUANT_BACKUP_MODE\n";
+}
+
+uint16_t read_le_u16(const uint8_t* ptr) {
+    return static_cast<uint16_t>(ptr[0]) | (static_cast<uint16_t>(ptr[1]) << 8);
+}
+
+uint32_t read_le_u32(const uint8_t* ptr) {
+    return static_cast<uint32_t>(ptr[0]) | (static_cast<uint32_t>(ptr[1]) << 8) | (static_cast<uint32_t>(ptr[2]) << 16) |
+           (static_cast<uint32_t>(ptr[3]) << 24);
+}
+
+std::vector<float> linear_resample(const std::vector<float>& input, uint32_t in_rate, uint32_t out_rate) {
+    if (input.empty()) {
+        return {};
+    }
+    if (in_rate == out_rate) {
+        return input;
+    }
+    const double ratio = static_cast<double>(out_rate) / static_cast<double>(in_rate);
+    const size_t out_size = std::max<size_t>(1, static_cast<size_t>(input.size() * ratio));
+
+    std::vector<float> output(out_size);
+    for (size_t i = 0; i < out_size; ++i) {
+        const double src_pos = static_cast<double>(i) / ratio;
+        const size_t idx0 = static_cast<size_t>(src_pos);
+        const size_t idx1 = std::min(idx0 + 1, input.size() - 1);
+        const double frac = src_pos - static_cast<double>(idx0);
+        output[i] = static_cast<float>((1.0 - frac) * static_cast<double>(input[idx0]) + frac * static_cast<double>(input[idx1]));
+    }
+    return output;
+}
+
+float decode_sample_to_f32(const uint8_t* ptr, uint16_t audio_format, uint16_t bits_per_sample) {
+    // audio_format: 1 = PCM integer, 3 = IEEE float
+    if (audio_format == 1) {
+        switch (bits_per_sample) {
+        case 8: {
+            // unsigned PCM8: [0,255] -> [-1,1)
+            const float v = static_cast<float>(ptr[0]);
+            return (v - 128.0f) / 128.0f;
+        }
+        case 16: {
+            int16_t v = 0;
+            std::memcpy(&v, ptr, sizeof(v));
+            return static_cast<float>(v) / 32768.0f;
+        }
+        case 24: {
+            int32_t v = (static_cast<int32_t>(ptr[0]) | (static_cast<int32_t>(ptr[1]) << 8) |
+                         (static_cast<int32_t>(ptr[2]) << 16));
+            if ((v & 0x00800000) != 0) {
+                v |= ~0x00FFFFFF;
+            }
+            return static_cast<float>(v) / 8388608.0f;
+        }
+        case 32: {
+            int32_t v = 0;
+            std::memcpy(&v, ptr, sizeof(v));
+            return static_cast<float>(v) / 2147483648.0f;
+        }
+        default:
+            throw std::runtime_error("Unsupported PCM bit depth: " + std::to_string(bits_per_sample));
+        }
+    }
+
+    if (audio_format == 3) {
+        if (bits_per_sample == 32) {
+            float v = 0.0f;
+            std::memcpy(&v, ptr, sizeof(v));
+            return v;
+        }
+        if (bits_per_sample == 64) {
+            double v = 0.0;
+            std::memcpy(&v, ptr, sizeof(v));
+            return static_cast<float>(v);
+        }
+        throw std::runtime_error("Unsupported IEEE float bit depth: " + std::to_string(bits_per_sample));
+    }
+
+    throw std::runtime_error("Unsupported wav audio_format: " + std::to_string(audio_format));
+}
+
+std::vector<float> read_wav_pcm_mono_or_stereo(const std::filesystem::path& wav_path, uint32_t target_sample_rate) {
+    std::ifstream in(wav_path, std::ios::binary);
+    if (!in.is_open()) {
+        throw std::runtime_error("Failed to open wav file: " + wav_path.string());
+    }
+
+    std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    if (bytes.size() < 44) {
+        throw std::runtime_error("Invalid wav file (too small): " + wav_path.string());
+    }
+
+    if (std::memcmp(bytes.data(), "RIFF", 4) != 0 || std::memcmp(bytes.data() + 8, "WAVE", 4) != 0) {
+        throw std::runtime_error("Unsupported wav container (expect RIFF/WAVE): " + wav_path.string());
+    }
+
+    uint16_t audio_format = 0;
+    uint16_t channels = 0;
+    uint32_t sample_rate = 0;
+    uint16_t bits_per_sample = 0;
+
+    size_t data_offset = 0;
+    size_t data_size = 0;
+
+    size_t offset = 12;
+    while (offset + 8 <= bytes.size()) {
+        const uint8_t* chunk = bytes.data() + offset;
+        const uint32_t chunk_size = read_le_u32(chunk + 4);
+        const size_t chunk_data_offset = offset + 8;
+        if (chunk_data_offset + chunk_size > bytes.size()) {
+            throw std::runtime_error("Corrupted wav chunk size in: " + wav_path.string());
+        }
+
+        if (std::memcmp(chunk, "fmt ", 4) == 0) {
+            if (chunk_size < 16) {
+                throw std::runtime_error("Invalid fmt chunk in wav: " + wav_path.string());
+            }
+            const uint8_t* fmt = bytes.data() + chunk_data_offset;
+            audio_format = read_le_u16(fmt + 0);
+            channels = read_le_u16(fmt + 2);
+            sample_rate = read_le_u32(fmt + 4);
+            bits_per_sample = read_le_u16(fmt + 14);
+        } else if (std::memcmp(chunk, "data", 4) == 0) {
+            data_offset = chunk_data_offset;
+            data_size = chunk_size;
+            break;
+        }
+
+        offset = chunk_data_offset + chunk_size + (chunk_size % 2);
+    }
+
+    if (channels != 1 && channels != 2) {
+        throw std::runtime_error("Only mono or stereo wav is supported: " + wav_path.string());
+    }
+    if (audio_format != 1 && audio_format != 3) {
+        throw std::runtime_error("Only PCM or IEEE float wav is supported: " + wav_path.string());
+    }
+    if (data_offset == 0 || data_size == 0) {
+        throw std::runtime_error("No audio data chunk found in wav: " + wav_path.string());
+    }
+
+    const size_t bytes_per_channel = static_cast<size_t>(bits_per_sample) / 8;
+    if (bytes_per_channel == 0 || (static_cast<size_t>(bits_per_sample) % 8) != 0) {
+        throw std::runtime_error("Unsupported non-byte-aligned bit depth: " + std::to_string(bits_per_sample));
+    }
+    const size_t bytes_per_frame = bytes_per_channel * channels;
+    if (bytes_per_frame == 0 || (data_size % bytes_per_frame) != 0) {
+        throw std::runtime_error("Corrupted wav data size/frame alignment: " + wav_path.string());
+    }
+
+    const size_t frames = data_size / bytes_per_frame;
+    const uint8_t* pcm = bytes.data() + data_offset;
+
+    std::vector<float> mono(frames);
+    for (size_t i = 0; i < frames; ++i) {
+        const uint8_t* frame_ptr = pcm + i * bytes_per_frame;
+        if (channels == 1) {
+            mono[i] = decode_sample_to_f32(frame_ptr, audio_format, bits_per_sample);
+        } else {
+            const float left = decode_sample_to_f32(frame_ptr, audio_format, bits_per_sample);
+            const float right = decode_sample_to_f32(frame_ptr + bytes_per_channel, audio_format, bits_per_sample);
+            mono[i] = 0.5f * (left + right);
+        }
+    }
+    if (target_sample_rate == 0) {
+        throw std::runtime_error("Invalid target sample rate: 0");
+    }
+    if (sample_rate != target_sample_rate) {
+        return linear_resample(mono, sample_rate, target_sample_rate);
+    }
+    return mono;
+}
+
+ov::genai::modeling::models::Qwen3ASRTextConfig to_text_cfg(const ov::genai::loaders::ModelConfig& cfg) {
+    using ov::genai::modeling::models::Qwen3ASRTextConfig;
+    Qwen3ASRTextConfig out;
+    out.architecture = "qwen3_asr";
+    out.vocab_size = cfg.vocab_size;
+    out.hidden_size = cfg.hidden_size;
+    out.intermediate_size = cfg.intermediate_size;
+    out.num_hidden_layers = cfg.num_hidden_layers;
+    out.num_attention_heads = cfg.num_attention_heads;
+    out.num_key_value_heads = cfg.num_key_value_heads > 0 ? cfg.num_key_value_heads : cfg.num_attention_heads;
+    out.head_dim = cfg.head_dim > 0 ? cfg.head_dim : (cfg.hidden_size / std::max(1, cfg.num_attention_heads));
+    out.max_position_embeddings = cfg.max_position_embeddings;
+    out.rms_norm_eps = cfg.rms_norm_eps;
+    out.rope_theta = cfg.rope_theta;
+    out.hidden_act = cfg.hidden_act;
+    out.attention_bias = cfg.attention_bias;
+    out.tie_word_embeddings = cfg.tie_word_embeddings;
+
+    if (out.hidden_size <= 0 || out.intermediate_size <= 0 || out.num_hidden_layers <= 0 ||
+        out.num_attention_heads <= 0 || out.vocab_size <= 0) {
+        throw std::runtime_error("Invalid text config parsed from config.json");
+    }
+    return out;
+}
+
+ov::genai::modeling::models::Qwen3ASRAudioConfig to_audio_cfg(const ov::genai::loaders::ModelConfig& cfg) {
+    using ov::genai::modeling::models::Qwen3ASRAudioConfig;
+    Qwen3ASRAudioConfig out;
+    out.architecture = "qwen3_asr_audio_encoder";
+    out.num_mel_bins = cfg.audio_num_mel_bins > 0 ? cfg.audio_num_mel_bins : out.num_mel_bins;
+    out.d_model = cfg.audio_hidden_size > 0 ? cfg.audio_hidden_size : (cfg.hidden_size > 0 ? cfg.hidden_size : out.d_model);
+    out.encoder_layers = cfg.audio_num_hidden_layers > 0 ? cfg.audio_num_hidden_layers
+                                                          : (cfg.num_hidden_layers > 0 ? cfg.num_hidden_layers : out.encoder_layers);
+    out.encoder_attention_heads = cfg.audio_num_attention_heads > 0 ? cfg.audio_num_attention_heads
+                                                                     : (cfg.num_attention_heads > 0 ? cfg.num_attention_heads : out.encoder_attention_heads);
+    out.encoder_ffn_dim = cfg.audio_intermediate_size > 0 ? cfg.audio_intermediate_size
+                                                           : (cfg.intermediate_size > 0 ? cfg.intermediate_size : out.encoder_ffn_dim);
+    out.max_source_positions = cfg.audio_max_position_embeddings > 0 ? cfg.audio_max_position_embeddings
+                                                                      : (cfg.max_position_embeddings > 0 ? cfg.max_position_embeddings : out.max_source_positions);
+    out.downsample_hidden_size = cfg.audio_downsample_hidden_size > 0 ? cfg.audio_downsample_hidden_size : out.downsample_hidden_size;
+    out.output_dim = cfg.audio_output_dim > 0 ? cfg.audio_output_dim : out.output_dim;
+    out.activation_function = !cfg.audio_hidden_act.empty() ? cfg.audio_hidden_act
+                                                             : (cfg.hidden_act.empty() ? out.activation_function : cfg.hidden_act);
+
+    if (out.d_model <= 0 || out.encoder_layers <= 0 || out.encoder_attention_heads <= 0 || out.encoder_ffn_dim <= 0) {
+        throw std::runtime_error("Invalid audio config parsed from config.json");
+    }
+    return out;
+}
+
+ov::Tensor make_i64(const ov::Shape& shape, int64_t value = 0) {
+    ov::Tensor t(ov::element::i64, shape);
+    std::fill(t.data<int64_t>(), t.data<int64_t>() + t.get_size(), value);
+    return t;
+}
+
+ov::Tensor make_i32(const ov::Shape& shape, int32_t value = 0) {
+    ov::Tensor t(ov::element::i32, shape);
+    std::fill(t.data<int32_t>(), t.data<int32_t>() + t.get_size(), value);
+    return t;
+}
+
+ov::Tensor make_bool(const ov::Shape& shape, bool value = true) {
+    ov::Tensor t(ov::element::boolean, shape);
+    std::fill(t.data<char>(), t.data<char>() + t.get_size(), static_cast<char>(value ? 1 : 0));
+    return t;
+}
+
+ov::Tensor make_audio_features(size_t batch, size_t mel_bins, size_t frames) {
+    ov::Tensor t(ov::element::f32, ov::Shape{batch, mel_bins, frames});
+    float* ptr = t.data<float>();
+    for (size_t i = 0; i < t.get_size(); ++i) {
+        ptr[i] = static_cast<float>((i % 97) - 48) / 64.0f;
+    }
+    return t;
+}
+
+ov::Tensor make_audio_features_from_wav(const std::filesystem::path& wav_path,
+                                        const std::filesystem::path& preprocessor_json,
+                                        size_t expected_mel_bins,
+                                        double* audio_duration_seconds = nullptr,
+                                        uint32_t* used_sample_rate = nullptr) {
+    ov::genai::WhisperFeatureExtractor extractor(preprocessor_json);
+    const uint32_t target_sample_rate = static_cast<uint32_t>(std::max<size_t>(1, extractor.sampling_rate));
+    if (used_sample_rate != nullptr) {
+        *used_sample_rate = target_sample_rate;
+    }
+    const std::vector<float> raw = read_wav_pcm_mono_or_stereo(wav_path, target_sample_rate);
+    if (raw.empty()) {
+        throw std::runtime_error("Input wav has no samples: " + wav_path.string());
+    }
+    if (audio_duration_seconds != nullptr) {
+        *audio_duration_seconds = static_cast<double>(raw.size()) / static_cast<double>(target_sample_rate);
+    }
+
+    ov::genai::WhisperFeatures features = extractor.extract(raw);
+    if (features.n_frames == 0 || features.feature_size == 0) {
+        throw std::runtime_error("Failed to extract audio features from wav: " + wav_path.string());
+    }
+
+    const size_t actual_mel_bins = features.feature_size;
+    const size_t frames = features.n_frames;
+    const size_t mel_bins = expected_mel_bins > 0 ? expected_mel_bins : actual_mel_bins;
+
+    ov::Tensor tensor(ov::element::f32, ov::Shape{1, mel_bins, frames});
+    float* dst = tensor.data<float>();
+    const float* src = features.data.data();
+
+    for (size_t m = 0; m < mel_bins; ++m) {
+        const float* src_row = (m < actual_mel_bins) ? (src + m * frames) : nullptr;
+        float* dst_row = dst + m * frames;
+        if (src_row != nullptr) {
+            std::copy(src_row, src_row + frames, dst_row);
+        } else {
+            std::fill(dst_row, dst_row + frames, 0.0f);
+        }
+    }
+
+    return tensor;
+}
+
+ov::Tensor make_position_ids_3d(size_t batch, size_t seq_len) {
+    ov::Tensor t(ov::element::i64, ov::Shape{3, batch, seq_len});
+    int64_t* ptr = t.data<int64_t>();
+    for (size_t plane = 0; plane < 3; ++plane) {
+        for (size_t b = 0; b < batch; ++b) {
+            for (size_t s = 0; s < seq_len; ++s) {
+                ptr[(plane * batch + b) * seq_len + s] = static_cast<int64_t>(s);
+            }
+        }
+    }
+    return t;
+}
+
+ov::Tensor make_i64_from_vector(const std::vector<int64_t>& values) {
+    ov::Tensor t(ov::element::i64, ov::Shape{1, values.size()});
+    std::copy(values.begin(), values.end(), t.data<int64_t>());
+    return t;
+}
+
+ov::Tensor make_audio_pos_mask_prefix(size_t batch, size_t seq_len, size_t audio_prefix_len) {
+    ov::Tensor t(ov::element::boolean, ov::Shape{batch, seq_len});
+    char* ptr = t.data<char>();
+    for (size_t b = 0; b < batch; ++b) {
+        for (size_t s = 0; s < seq_len; ++s) {
+            ptr[b * seq_len + s] = static_cast<char>(s < audio_prefix_len ? 1 : 0);
+        }
+    }
+    return t;
+}
+
+ov::Tensor make_audio_pos_mask_from_flags(const std::vector<char>& flags) {
+    ov::Tensor t(ov::element::boolean, ov::Shape{1, flags.size()});
+    char* ptr = t.data<char>();
+    std::copy(flags.begin(), flags.end(), ptr);
+    return t;
+}
+
+ov::Tensor make_padded_audio_embeds(const ov::Tensor& audio_embeds, size_t target_seq_len) {
+    const auto src_shape = audio_embeds.get_shape();
+    if (src_shape.size() != 3) {
+        throw std::runtime_error("audio_embeds rank must be 3 for padding");
+    }
+    const size_t batch = src_shape[0];
+    const size_t src_seq = src_shape[1];
+    const size_t hidden = src_shape[2];
+    if (target_seq_len < src_seq) {
+        throw std::runtime_error("target_seq_len is smaller than audio_embeds sequence length");
+    }
+
+    ov::Tensor out(audio_embeds.get_element_type(), ov::Shape{batch, target_seq_len, hidden});
+    if (out.get_element_type() != ov::element::f32 || audio_embeds.get_element_type() != ov::element::f32) {
+        throw std::runtime_error("Expected f32 audio_embeds tensor");
+    }
+
+    const float* src = audio_embeds.data<const float>();
+    float* dst = out.data<float>();
+    std::fill(dst, dst + out.get_size(), 0.0f);
+
+    const size_t copy_per_batch = src_seq * hidden;
+    const size_t dst_stride = target_seq_len * hidden;
+    for (size_t b = 0; b < batch; ++b) {
+        std::copy(src + b * copy_per_batch,
+                  src + b * copy_per_batch + copy_per_batch,
+                  dst + b * dst_stride);
+    }
+    return out;
+}
+
+std::vector<int64_t> tensor_row_to_i64_vector(const ov::Tensor& t) {
+    const auto shape = t.get_shape();
+    if (shape.size() != 2 || shape[0] != 1 || t.get_element_type() != ov::element::i64) {
+        throw std::runtime_error("Expected tensor shape [1, N] with i64 type");
+    }
+    const int64_t* src = t.data<const int64_t>();
+    return std::vector<int64_t>(src, src + shape[1]);
+}
+
+ov::Tensor make_audio_embeds_for_mask_positions(const ov::Tensor& audio_embeds, const std::vector<char>& audio_flags) {
+    const auto src_shape = audio_embeds.get_shape();
+    if (src_shape.size() != 3 || src_shape[0] != 1 || audio_embeds.get_element_type() != ov::element::f32) {
+        throw std::runtime_error("Expected audio_embeds shape [1, T, H] with f32 type");
+    }
+
+    const size_t src_seq = src_shape[1];
+    const size_t hidden = src_shape[2];
+    size_t true_count = 0;
+    for (char v : audio_flags) {
+        true_count += (v != 0) ? 1 : 0;
+    }
+    if (true_count != src_seq) {
+        throw std::runtime_error("Audio mask true-count must match audio_embeds sequence length");
+    }
+
+    ov::Tensor out(ov::element::f32, ov::Shape{1, audio_flags.size(), hidden});
+    float* dst = out.data<float>();
+    std::fill(dst, dst + out.get_size(), 0.0f);
+
+    const float* src = audio_embeds.data<const float>();
+    size_t src_idx = 0;
+    for (size_t pos = 0; pos < audio_flags.size(); ++pos) {
+        if (audio_flags[pos] == 0) {
+            continue;
+        }
+        std::copy(src + src_idx * hidden,
+                  src + (src_idx + 1) * hidden,
+                  dst + pos * hidden);
+        ++src_idx;
+    }
+    return out;
+}
+
+int64_t argmax_last_token_id(const ov::Tensor& logits) {
+    const auto shape = logits.get_shape();
+    if (shape.size() != 3 || shape[0] == 0 || shape[1] == 0 || shape[2] == 0) {
+        throw std::runtime_error("Unexpected logits shape for argmax");
+    }
+
+    const size_t vocab = shape[2];
+    const size_t offset = (shape[0] - 1) * shape[1] * vocab + (shape[1] - 1) * vocab;
+    const float* row = logits.data<const float>() + offset;
+
+    size_t best_idx = 0;
+    float best_val = row[0];
+    for (size_t i = 1; i < vocab; ++i) {
+        if (row[i] > best_val) {
+            best_val = row[i];
+            best_idx = i;
+        }
+    }
+    return static_cast<int64_t>(best_idx);
+}
+
+int64_t argmax_last_token_id_excluding(const ov::Tensor& logits, const std::unordered_set<int64_t>& excluded_ids) {
+    const auto shape = logits.get_shape();
+    if (shape.size() != 3 || shape[0] == 0 || shape[1] == 0 || shape[2] == 0) {
+        throw std::runtime_error("Unexpected logits shape for argmax");
+    }
+
+    const size_t vocab = shape[2];
+    const size_t offset = (shape[0] - 1) * shape[1] * vocab + (shape[1] - 1) * vocab;
+    const float* row = logits.data<const float>() + offset;
+
+    int64_t best_idx = -1;
+    float best_val = -std::numeric_limits<float>::infinity();
+    for (size_t i = 0; i < vocab; ++i) {
+        const int64_t tid = static_cast<int64_t>(i);
+        if (excluded_ids.find(tid) != excluded_ids.end()) {
+            continue;
+        }
+        if (row[i] > best_val) {
+            best_val = row[i];
+            best_idx = tid;
+        }
+    }
+
+    if (best_idx < 0) {
+        return argmax_last_token_id(logits);
+    }
+    return best_idx;
+}
+
+bool has_recent_ngram_loop(const std::vector<int64_t>& ids, size_t ngram, size_t repeats) {
+    if (ngram == 0 || repeats < 2) {
+        return false;
+    }
+    const size_t needed = ngram * repeats;
+    if (ids.size() < needed) {
+        return false;
+    }
+
+    const size_t base = ids.size() - needed;
+    for (size_t r = 1; r < repeats; ++r) {
+        for (size_t i = 0; i < ngram; ++i) {
+            if (ids[base + i] != ids[base + r * ngram + i]) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool trim_recent_duplicate_ngram(std::vector<int64_t>& ids, size_t min_ngram, size_t max_ngram) {
+    if (min_ngram == 0 || max_ngram < min_ngram) {
+        return false;
+    }
+    const size_t capped_max = std::min(max_ngram, ids.size() / 2);
+    if (capped_max < min_ngram) {
+        return false;
+    }
+
+    // Prefer trimming longer duplicated tails first.
+    for (size_t n = capped_max; n >= min_ngram; --n) {
+        const size_t off0 = ids.size() - 2 * n;
+        const size_t off1 = ids.size() - n;
+        bool same = true;
+        for (size_t i = 0; i < n; ++i) {
+            if (ids[off0 + i] != ids[off1 + i]) {
+                same = false;
+                break;
+            }
+        }
+        if (same) {
+            ids.resize(ids.size() - n);
+            return true;
+        }
+        if (n == min_ngram) {
+            break;
+        }
+    }
+    return false;
+}
+
+bool is_language_tag_token(const std::string& token) {
+    // Expected shape like: <|en|>, <|zh|>, <|yue|>
+    if (token.size() < 6) {
+        return false;
+    }
+    if (token.rfind("<|", 0) != 0 || token.substr(token.size() - 2) != "|>") {
+        return false;
+    }
+    const std::string tag = token.substr(2, token.size() - 4);
+    if (tag.size() < 2 || tag.size() > 5) {
+        return false;
+    }
+    for (char c : tag) {
+        if (!std::isalpha(static_cast<unsigned char>(c))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool is_text_stop_token(const std::string& token) {
+    // Common end markers used by Qwen-family chat/tokenizers.
+    return token == "<|endoftext|>" || token == "<|im_end|>" || token == "<|eot_id|>";
+}
+
+std::string detect_language_from_tokens(ov::genai::Tokenizer& tokenizer, const std::vector<int64_t>& generated_ids) {
+    for (size_t i = 0; i < generated_ids.size() && i < 8; ++i) {
+        const std::string token = tokenizer.decode({generated_ids[i]}, {ov::genai::skip_special_tokens(false)});
+        if (is_language_tag_token(token)) {
+            return token;
+        }
+    }
+    return "unknown";
+}
+
+std::string detect_language_from_language_prefix_tokens(ov::genai::Tokenizer& tokenizer,
+                                                        const std::vector<int64_t>& generated_ids) {
+    if (generated_ids.size() < 2) {
+        return {};
+    }
+
+    std::string first = trim_copy(tokenizer.decode({generated_ids[0]}, {ov::genai::skip_special_tokens(false)}));
+    std::string first_lower = first;
+    std::transform(first_lower.begin(), first_lower.end(), first_lower.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    if (first_lower != "language") {
+        return {};
+    }
+
+    const std::string second = trim_copy(tokenizer.decode({generated_ids[1]}, {ov::genai::skip_special_tokens(false)}));
+    if (second.empty()) {
+        return {};
+    }
+    return normalize_language_name(second);
+}
+
+int64_t find_token_id(const std::unordered_map<std::string, int64_t>& vocab,
+                      const std::initializer_list<std::string>& candidates,
+                      int64_t fallback = -1) {
+    for (const auto& tok : candidates) {
+        const auto it = vocab.find(tok);
+        if (it != vocab.end()) {
+            return it->second;
+        }
+    }
+    return fallback;
+}
+
+void add_token_if_found(const std::unordered_map<std::string, int64_t>& vocab,
+                        const std::string& token,
+                        std::unordered_set<int64_t>& out) {
+    const auto it = vocab.find(token);
+    if (it != vocab.end()) {
+        out.insert(it->second);
+    }
+}
+
+std::string trim_copy(const std::string& s) {
+    const auto begin = s.find_first_not_of(" \t\r\n");
+    if (begin == std::string::npos) {
+        return {};
+    }
+    const auto end = s.find_last_not_of(" \t\r\n");
+    return s.substr(begin, end - begin + 1);
+}
+
+std::string normalize_language_name(const std::string& raw) {
+    const std::string s = trim_copy(raw);
+    if (s.empty()) {
+        return {};
+    }
+
+    std::string out;
+    out.reserve(s.size());
+    bool seen_lower = false;
+    for (char c : s) {
+        if (!std::isalpha(static_cast<unsigned char>(c))) {
+            break;
+        }
+        if (!out.empty() && seen_lower && std::isupper(static_cast<unsigned char>(c))) {
+            break;
+        }
+        if (std::islower(static_cast<unsigned char>(c))) {
+            seen_lower = true;
+        }
+        out.push_back(c);
+    }
+    return out;
+}
+
+std::string clean_transcript_text(const std::string& raw_text) {
+    std::string out = raw_text;
+    const std::array<std::string, 6> control_tokens = {
+        "<asr_text>", "<|audio_start|>", "<|audio_end|>", "<|audio_pad|>", "<|im_start|>", "<|im_end|>"};
+    for (const auto& token : control_tokens) {
+        std::string::size_type pos = 0;
+        while ((pos = out.find(token, pos)) != std::string::npos) {
+            out.erase(pos, token.size());
+        }
+    }
+    out = trim_copy(out);
+    while (!out.empty() && (out.front() == '.' || out.front() == ',' || out.front() == ';' || out.front() == ':' ||
+                             out.front() == '!' || out.front() == '?' || std::isspace(static_cast<unsigned char>(out.front())))) {
+        out.erase(out.begin());
+    }
+    return trim_copy(out);
+}
+
+std::string extract_language_from_prefix(std::string& text) {
+    // Example prefix seen in some generations: "language English ..."
+    static const std::regex lang_prefix(R"(^\s*language\s+([A-Za-z]+)\s*)", std::regex_constants::icase);
+    std::smatch m;
+    if (std::regex_search(text, m, lang_prefix) && m.size() >= 2) {
+        const std::string lang = normalize_language_name(m[1].str());
+        text.erase(0, static_cast<size_t>(m.position(0) + m.length(0)));
+        text = trim_copy(text);
+        return lang;
+    }
+    return {};
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) try {
+    if (argc < 2 || std::string(argv[1]) == "-h" || std::string(argv[1]) == "--help") {
+        print_usage(argv[0]);
+        return argc < 2 ? 1 : 0;
+    }
+
+    std::vector<std::string> positional;
+    std::optional<std::filesystem::path> wav_path;
+    std::optional<std::string> device_override;
+    std::optional<int32_t> max_new_tokens_override;
+    std::optional<std::string> prompt_override;
+    bool text_only = false;
+    bool cache_model = false;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--wav") {
+            if (i + 1 >= argc) {
+                throw std::runtime_error("Missing value for --wav");
+            }
+            wav_path = std::filesystem::path(argv[++i]);
+        } else if (arg == "--device") {
+            if (i + 1 >= argc) {
+                throw std::runtime_error("Missing value for --device");
+            }
+            device_override = std::string(argv[++i]);
+        } else if (arg == "--max_new_tokens") {
+            if (i + 1 >= argc) {
+                throw std::runtime_error("Missing value for --max_new_tokens");
+            }
+            max_new_tokens_override = std::stoi(argv[++i]);
+        } else if (arg == "--prompt") {
+            if (i + 1 >= argc) {
+                throw std::runtime_error("Missing value for --prompt");
+            }
+            prompt_override = std::string(argv[++i]);
+        } else if (arg == "--text-only" || arg == "--text_only") {
+            text_only = true;
+        } else if (arg == "--cached-model" || arg == "--cache-model") {
+            cache_model = true;
+        } else {
+            positional.push_back(arg);
+        }
+    }
+
+    if (positional.empty()) {
+        throw std::runtime_error("Missing <TEXT_MODEL_DIR>");
+    }
+    if (positional.size() > 3) {
+        throw std::runtime_error("Too many positional arguments");
+    }
+
+    const std::filesystem::path text_model_dir = positional[0];
+    const std::filesystem::path audio_model_dir = positional.size() > 1 ? std::filesystem::path(positional[1]) : text_model_dir;
+    std::string device = positional.size() > 2 ? positional[2] : "GPU";
+    if (device_override.has_value()) {
+        device = *device_override;
+    }
+    const int32_t max_new_tokens = max_new_tokens_override.has_value() ? *max_new_tokens_override : 128;
+    if (max_new_tokens <= 0) {
+        throw std::runtime_error("--max_new_tokens must be > 0");
+    }
+
+    const auto text_loader_cfg = ov::genai::loaders::ModelConfig::from_hf_json(text_model_dir / "config.json");
+    const auto audio_loader_cfg = text_only ? text_loader_cfg
+                                            : ov::genai::loaders::ModelConfig::from_hf_json(audio_model_dir / "config.json");
+
+    const auto text_cfg = to_text_cfg(text_loader_cfg);
+    const auto audio_cfg = to_audio_cfg(audio_loader_cfg);
+
+    std::shared_ptr<ov::Model> text_model;
+    std::shared_ptr<ov::Model> audio_model;
+    const bool expect_audio_inputs_in_text_model = !text_only;
+    const std::filesystem::path text_xml = text_model_dir /
+        (expect_audio_inputs_in_text_model ? "modeling_qwen3_asr_text_with_audio.xml"
+                                           : "modeling_qwen3_asr_text_only.xml");
+    const std::filesystem::path text_bin = text_model_dir /
+        (expect_audio_inputs_in_text_model ? "modeling_qwen3_asr_text_with_audio.bin"
+                                           : "modeling_qwen3_asr_text_only.bin");
+    const std::filesystem::path audio_xml = audio_model_dir / "modeling_qwen3_asr_audio.xml";
+    const std::filesystem::path audio_bin = audio_model_dir / "modeling_qwen3_asr_audio.bin";
+
+    auto quant_cfg = ov::genai::modeling::weights::parse_quantization_config_from_env();
+    if (quant_cfg.enabled() && quant_cfg.group_size <= 0) {
+        throw std::runtime_error(
+            "OV_GENAI_INFLIGHT_QUANT_GROUP_SIZE must be > 0 when OV_GENAI_INFLIGHT_QUANT_MODE is enabled");
+    }
+    std::cout << "[quant] enabled=" << (quant_cfg.enabled() ? "true" : "false")
+              << ", group_size=" << quant_cfg.group_size << std::endl;
+
+    ov::Core core;
+    bool load_text_from_ir = false;
+    if (cache_model) {
+        if (has_ir_model_pair(text_xml, text_bin)) {
+            auto candidate = core.read_model(text_xml.string(), text_bin.string());
+            if (!text_model_cache_supports_mode(candidate, expect_audio_inputs_in_text_model)) {
+                std::cout << "[cache] skipped incompatible text IR: " << text_xml.string()
+                          << " (expected audio_inputs="
+                          << (expect_audio_inputs_in_text_model ? "true" : "false") << ")" << std::endl;
+            } else {
+                text_model = std::move(candidate);
+                load_text_from_ir = true;
+                std::cout << "[cache] loaded text IR: " << text_xml.string() << std::endl;
+            }
+        }
+    }
+    const bool load_audio_from_ir = !text_only && cache_model && has_ir_model_pair(audio_xml, audio_bin);
+
+    const auto build_start = std::chrono::steady_clock::now();
+    if (!text_only && load_audio_from_ir) {
+        audio_model = core.read_model(audio_xml.string(), audio_bin.string());
+        std::cout << "[cache] loaded audio IR: " << audio_xml.string() << std::endl;
+    }
+
+    if (!load_text_from_ir) {
+        auto text_data = ov::genai::safetensors::load_safetensors(text_model_dir);
+        ov::genai::safetensors::SafetensorsWeightSource text_source(std::move(text_data));
+        ov::genai::safetensors::SafetensorsWeightFinalizer text_finalizer(quant_cfg);
+        text_model = ov::genai::modeling::models::create_qwen3_asr_text_model(
+            text_cfg,
+            text_source,
+            text_finalizer,
+            false,
+            !text_only);
+    }
+
+    if (!text_only && !load_audio_from_ir) {
+        auto audio_data = ov::genai::safetensors::load_safetensors(audio_model_dir);
+        ov::genai::safetensors::SafetensorsWeightSource audio_source(std::move(audio_data));
+        ov::genai::safetensors::SafetensorsWeightFinalizer audio_finalizer;
+        audio_model = ov::genai::modeling::models::create_qwen3_asr_audio_encoder_model(
+            audio_cfg,
+            audio_source,
+            audio_finalizer);
+    }
+    const auto build_end = std::chrono::steady_clock::now();
+
+    if (cache_model) {
+        if (!load_text_from_ir) {
+            ov::serialize(text_model, text_xml.string(), text_bin.string());
+            std::cout << "[cache] saved text IR: " << text_xml.string() << std::endl;
+        }
+
+        if (!text_only && !load_audio_from_ir) {
+            ov::serialize(audio_model, audio_xml.string(), audio_bin.string());
+            std::cout << "[cache] saved audio IR: " << audio_xml.string() << std::endl;
+        }
+    }
+
+    const auto compile_start = std::chrono::steady_clock::now();
+    auto compiled_text = core.compile_model(text_model, device);
+    std::optional<ov::CompiledModel> compiled_audio;
+    if (!text_only) {
+        compiled_audio.emplace(core.compile_model(audio_model, device));
+    }
+    const auto compile_end = std::chrono::steady_clock::now();
+
+    std::optional<ov::InferRequest> audio_request;
+    if (!text_only) {
+        audio_request.emplace(compiled_audio->create_infer_request());
+    }
+    auto text_request = compiled_text.create_infer_request();
+
+    const size_t batch = 1;
+    const size_t mel_bins = static_cast<size_t>(std::max(1, audio_cfg.num_mel_bins));
+    ov::Tensor input_audio_features;
+    double input_audio_duration_seconds = 0.0;
+    uint32_t input_audio_sample_rate = 0;
+    const auto feature_extract_start = std::chrono::steady_clock::now();
+    if (!text_only) {
+        if (wav_path.has_value()) {
+            std::filesystem::path preprocessor_cfg = audio_model_dir / "preprocessor_config.json";
+            if (!std::filesystem::exists(preprocessor_cfg)) {
+                preprocessor_cfg = text_model_dir / "preprocessor_config.json";
+            }
+            input_audio_features = make_audio_features_from_wav(*wav_path,
+                                                                preprocessor_cfg,
+                                                                mel_bins,
+                                                                &input_audio_duration_seconds,
+                                                                &input_audio_sample_rate);
+        } else {
+            input_audio_features = make_audio_features(batch, mel_bins, 300);
+            input_audio_duration_seconds = static_cast<double>(input_audio_features.get_shape()[2]) / 100.0;
+        }
+    }
+    const auto feature_extract_end = std::chrono::steady_clock::now();
+
+    const auto audio_encode_start = std::chrono::steady_clock::now();
+    ov::Tensor audio_embeds;
+    ov::Tensor audio_out_lengths;
+    ov::Shape embeds_shape;
+    size_t audio_seq_len = 0;
+    if (!text_only) {
+        const size_t audio_frames = input_audio_features.get_shape()[2];
+
+        audio_request->set_tensor(ov::genai::modeling::models::Qwen3ASRAudioIO::kInputAudioFeatures, input_audio_features);
+
+        auto input_lengths = make_i64({batch});
+        input_lengths.data<int64_t>()[0] = static_cast<int64_t>(audio_frames);
+        audio_request->set_tensor(ov::genai::modeling::models::Qwen3ASRAudioIO::kAudioFeatureLengths, input_lengths);
+
+        audio_request->infer();
+        audio_embeds = audio_request->get_tensor(ov::genai::modeling::models::Qwen3ASRAudioIO::kAudioEmbeds);
+        audio_out_lengths =
+            audio_request->get_tensor(ov::genai::modeling::models::Qwen3ASRAudioIO::kAudioOutputLengths);
+
+        embeds_shape = audio_embeds.get_shape();
+        if (embeds_shape.size() != 3) {
+            throw std::runtime_error("Audio encoder output rank must be 3");
+        }
+
+        audio_seq_len = embeds_shape[1];
+        const size_t embed_dim = embeds_shape[2];
+
+        if (embed_dim != static_cast<size_t>(text_cfg.hidden_size)) {
+            throw std::runtime_error("audio_embeds hidden dimension does not match text hidden_size");
+        }
+    }
+    const auto audio_encode_end = std::chrono::steady_clock::now();
+
+    ov::genai::Tokenizer tokenizer(text_model_dir, ov::AnyMap{{"fix_mistral_regex", true}});
+    const auto vocab = tokenizer.get_vocab();
+    const int64_t audio_pad_token_id = find_token_id(vocab, {"<|audio_pad|>"}, -1);
+    if (!text_only && audio_pad_token_id < 0) {
+        throw std::runtime_error("Failed to find <|audio_pad|> token id in tokenizer vocab");
+    }
+
+    int64_t bos_token_id = tokenizer.get_bos_token_id();
+    const int64_t eos_token_id = tokenizer.get_eos_token_id();
+    if (bos_token_id < 0) {
+        bos_token_id = eos_token_id >= 0 ? eos_token_id : 1;
+    }
+
+    std::string instruction_prompt;
+    if (text_only) {
+        instruction_prompt = prompt_override.value_or("Please answer briefly: hello.");
+    } else {
+        // Approximate the Python processor instruction path:
+        // <|audio_start|><|audio_pad|><|audio_end|>Transcribe this audio.
+        instruction_prompt =
+            "<|im_start|>user\n<|audio_start|><|audio_pad|><|audio_end|>Transcribe this audio.<|im_end|>\n<|im_start|>assistant\n";
+    }
+    auto encoded_prompt = tokenizer.encode(instruction_prompt, {ov::genai::add_special_tokens(false)});
+    std::vector<int64_t> prompt_ids = tensor_row_to_i64_vector(encoded_prompt.input_ids);
+
+    std::vector<int64_t> input_ids;
+    input_ids.reserve(prompt_ids.size() + audio_seq_len + static_cast<size_t>(max_new_tokens));
+    if (text_only) {
+        input_ids = prompt_ids;
+        if (input_ids.empty()) {
+            input_ids.push_back(bos_token_id);
+        }
+    } else {
+        bool replaced_audio_placeholder = false;
+        for (int64_t tid : prompt_ids) {
+            if (!replaced_audio_placeholder && tid == audio_pad_token_id) {
+                input_ids.insert(input_ids.end(), audio_seq_len, audio_pad_token_id);
+                replaced_audio_placeholder = true;
+            } else {
+                input_ids.push_back(tid);
+            }
+        }
+        if (!replaced_audio_placeholder) {
+            // Fallback: if template/prompt changed, keep sample functional.
+            input_ids.insert(input_ids.begin(), audio_seq_len, audio_pad_token_id);
+            input_ids.push_back(bos_token_id);
+        }
+    }
+    const size_t prompt_token_size = input_ids.size();
+
+    std::vector<char> base_audio_pos_flags(input_ids.size(), 0);
+    for (size_t i = 0; i < input_ids.size(); ++i) {
+        if (input_ids[i] == audio_pad_token_id) {
+            base_audio_pos_flags[i] = 1;
+        }
+    }
+
+    std::vector<int64_t> generated_ids;
+    generated_ids.reserve(static_cast<size_t>(max_new_tokens));
+    int64_t prev_token_id = std::numeric_limits<int64_t>::min();
+    int32_t same_token_run = 0;
+
+    std::unordered_set<int64_t> excluded_decode_ids;
+    add_token_if_found(vocab, "<|audio_pad|>", excluded_decode_ids);
+    add_token_if_found(vocab, "<|audio_start|>", excluded_decode_ids);
+    add_token_if_found(vocab, "<|audio_end|>", excluded_decode_ids);
+    add_token_if_found(vocab, "<|im_start|>", excluded_decode_ids);
+    add_token_if_found(vocab, "<|im_end|>", excluded_decode_ids);
+    add_token_if_found(vocab, "<non_speech>", excluded_decode_ids);
+    add_token_if_found(vocab, "<asr_text>", excluded_decode_ids);
+    add_token_if_found(vocab, "<|asr_text|>", excluded_decode_ids);
+    for (int i = 1; i <= 27; ++i) {
+        add_token_if_found(vocab, "<blank" + std::to_string(i) + ">", excluded_decode_ids);
+    }
+
+    const int64_t dot_token_id = find_token_id(vocab, {"."}, -1);
+    const int64_t excl_token_id = find_token_id(vocab, {"!"}, -1);
+    const int64_t qmark_token_id = find_token_id(vocab, {"?"}, -1);
+
+    ov::Shape logits_shape;
+    double ttft_ms = 0.0;
+    double decode_ms = 0.0;
+    size_t decode_tail_tokens = 0;
+    size_t infer_steps = 0;
+    const auto asr_infer_start = std::chrono::steady_clock::now();
+
+    for (int32_t step = 0; step < max_new_tokens; ++step) {
+        // We run full-sequence decode each step; clear internal KV state to avoid
+        // stateful-cache shape accumulation across iterations.
+        text_request.reset_state();
+
+        const size_t seq_len = input_ids.size();
+        std::vector<char> step_audio_flags = base_audio_pos_flags;
+        if (seq_len > step_audio_flags.size()) {
+            step_audio_flags.resize(seq_len, 0);
+        }
+
+        text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kInputIds,
+                                make_i64_from_vector(input_ids));
+        text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kAttentionMask,
+                                make_i64({batch, seq_len}, 1));
+        text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kPositionIds,
+                                make_position_ids_3d(batch, seq_len));
+        text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kBeamIdx,
+                                make_i32({batch}, 0));
+        if (!text_only) {
+            ov::Tensor step_audio_embeds = make_audio_embeds_for_mask_positions(audio_embeds, step_audio_flags);
+            text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kAudioEmbeds,
+                                    step_audio_embeds);
+            text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kAudioPosMask,
+                                    make_audio_pos_mask_from_flags(step_audio_flags));
+        }
+
+        const auto step_start = std::chrono::steady_clock::now();
+        text_request.infer();
+        const auto step_end = std::chrono::steady_clock::now();
+
+        const double step_ms = elapsed_ms(step_start, step_end);
+        if (step == 0) {
+            ttft_ms = step_ms;
+        }
+        infer_steps += 1;
+
+        ov::Tensor logits = text_request.get_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kLogits);
+        logits_shape = logits.get_shape();
+        const int64_t next_token_id = argmax_last_token_id_excluding(logits, excluded_decode_ids);
+        const std::string next_token_text = tokenizer.decode({next_token_id}, {ov::genai::skip_special_tokens(false)});
+
+        if ((eos_token_id >= 0 && next_token_id == eos_token_id) || is_text_stop_token(next_token_text)) {
+            break;
+        }
+
+        if (next_token_id == prev_token_id) {
+            ++same_token_run;
+        } else {
+            prev_token_id = next_token_id;
+            same_token_run = 1;
+        }
+        if (same_token_run >= 32) {
+            break;
+        }
+
+        generated_ids.push_back(next_token_id);
+        input_ids.push_back(next_token_id);
+
+        // Additional anti-degeneracy stop criteria for text-only path.
+        if (text_only) {
+            if (has_recent_ngram_loop(generated_ids, 8, 3) || has_recent_ngram_loop(generated_ids, 12, 3)) {
+                break;
+            }
+            if (generated_ids.size() >= 64) {
+                if (next_token_id == dot_token_id || next_token_id == excl_token_id || next_token_id == qmark_token_id) {
+                    break;
+                }
+            }
+        } else {
+            // ASR outputs can get stuck in repeated phrase loops; stop early when
+            // recent n-grams are repeated to keep transcript quality stable.
+            bool repeated_loop = has_recent_ngram_loop(generated_ids, 8, 3) ||
+                                 has_recent_ngram_loop(generated_ids, 12, 3) ||
+                                 has_recent_ngram_loop(generated_ids, 16, 2);
+            if (!repeated_loop) {
+                // Some ASR loops are shorter (e.g., ~10-15 tokens repeated twice).
+                for (size_t n = 6; n <= 16; ++n) {
+                    if (has_recent_ngram_loop(generated_ids, n, 2)) {
+                        repeated_loop = true;
+                        break;
+                    }
+                }
+            }
+            if (repeated_loop) {
+                break;
+            }
+        }
+
+        if (step > 0) {
+            decode_ms += step_ms;
+            decode_tail_tokens += 1;
+        }
+    }
+    const auto asr_infer_end = std::chrono::steady_clock::now();
+
+    if (!text_only) {
+        // If we stopped right after closing a duplicated tail, keep only one copy.
+        while (trim_recent_duplicate_ngram(generated_ids, 6, 16)) {
+        }
+    }
+
+    std::string transcript_text;
+    if (!generated_ids.empty()) {
+        transcript_text = tokenizer.decode(generated_ids, {ov::genai::skip_special_tokens(true)});
+    }
+    transcript_text = clean_transcript_text(transcript_text);
+
+    std::string language_tag = detect_language_from_tokens(tokenizer, generated_ids);
+    const std::string language_from_tokens = detect_language_from_language_prefix_tokens(tokenizer, generated_ids);
+    if (!language_from_tokens.empty()) {
+        language_tag = language_from_tokens;
+    }
+    if (language_tag == "unknown") {
+        const std::string language_from_text = extract_language_from_prefix(transcript_text);
+        if (!language_from_text.empty()) {
+            language_tag = language_from_text;
+        }
+    }
+    if (text_only && language_tag == "unknown") {
+        language_tag = "n/a";
+    }
+
+    std::string preview;
+    const size_t preview_count = std::min<size_t>(generated_ids.size(), 10);
+    for (size_t i = 0; i < preview_count; ++i) {
+        if (i > 0) {
+            preview += " | ";
+        }
+        preview += std::to_string(generated_ids[i]);
+        preview += ":";
+        preview += tokenizer.decode({generated_ids[i]}, {ov::genai::skip_special_tokens(false)});
+    }
+
+    std::cout << "Qwen3-ASR smoke run completed" << std::endl;
+    std::cout << std::fixed << std::setprecision(2);
+    std::cout << "  device: " << device << std::endl;
+    std::cout << "  text_only: " << (text_only ? "true" : "false") << std::endl;
+    if (wav_path.has_value()) {
+        std::cout << "  wav: " << wav_path->string() << std::endl;
+    }
+    if (!text_only) {
+        std::cout << "  audio_embeds shape: [" << embeds_shape[0] << ", " << embeds_shape[1] << ", " << embeds_shape[2]
+                  << "]" << std::endl;
+        std::cout << "  audio_output_lengths[0]: " << audio_out_lengths.data<int64_t>()[0] << std::endl;
+        if (input_audio_sample_rate > 0) {
+            std::cout << "  audio_input_sample_rate_hz: " << input_audio_sample_rate << std::endl;
+        }
+    }
+    std::cout << "  logits shape: [" << logits_shape[0] << ", " << logits_shape[1] << ", " << logits_shape[2] << "]"
+              << std::endl;
+    std::cout << "  generated tokens: " << generated_ids.size() << std::endl;
+    std::cout << "  token preview: " << preview << std::endl;
+    std::cout << "  language: " << language_tag << std::endl;
+    std::cout << "  text: " << transcript_text << std::endl;
+
+    const double model_build_ms = elapsed_ms(build_start, build_end);
+    const double model_compile_ms = elapsed_ms(compile_start, compile_end);
+    const double feature_extract_ms = elapsed_ms(feature_extract_start, feature_extract_end);
+    const double audio_encode_ms = elapsed_ms(audio_encode_start, audio_encode_end);
+    const double asr_infer_ms = elapsed_ms(asr_infer_start, asr_infer_end);
+    const double tpot_ms = decode_tail_tokens > 0 ? (decode_ms / static_cast<double>(decode_tail_tokens)) : 0.0;
+    const double throughput = decode_ms > 0.0 ? (static_cast<double>(decode_tail_tokens) * 1000.0 / decode_ms) : 0.0;
+    const double asr_rtf = (!text_only && input_audio_duration_seconds > 0.0)
+                               ? (asr_infer_ms / 1000.0) / input_audio_duration_seconds
+                               : 0.0;
+
+    // Keep compatibility with reporting scripts that scan for these labels.
+    std::cout << "Prompt token size: " << prompt_token_size << std::endl;
+    std::cout << "Output token size: " << generated_ids.size() << std::endl;
+    std::cout << "Generate time: " << asr_infer_ms << " ms" << std::endl;
+    std::cout << "TTFT: " << ttft_ms << " ms" << std::endl;
+    if (decode_tail_tokens > 0) {
+        std::cout << "TPOT: " << tpot_ms << " ms" << std::endl;
+        std::cout << "Throughput: " << throughput << " tokens/s" << std::endl;
+    } else {
+        std::cout << "TPOT: N/A" << std::endl;
+        std::cout << "Throughput: N/A" << std::endl;
+    }
+
+    std::cout << "  perf.build_model_ms: " << model_build_ms << std::endl;
+    std::cout << "  perf.compile_model_ms: " << model_compile_ms << std::endl;
+    std::cout << "  perf.feature_extract_ms: " << feature_extract_ms << std::endl;
+    std::cout << "  perf.audio_encode_ms: " << audio_encode_ms << std::endl;
+    if (!text_only) {
+        std::cout << "  perf.audio_duration_s: " << input_audio_duration_seconds << std::endl;
+        std::cout << "  perf.asr_infer_ms: " << asr_infer_ms << std::endl;
+        std::cout << "  perf.asr_rtf: " << asr_rtf << std::endl;
+    }
+    std::cout << "  perf.ttft_ms: " << ttft_ms << std::endl;
+    std::cout << "  perf.decode_ms: " << decode_ms << std::endl;
+    std::cout << "  perf.decode_steps: " << decode_tail_tokens << std::endl;
+    std::cout << "  perf.infer_steps_total: " << infer_steps << std::endl;
+    if (decode_tail_tokens > 0) {
+        std::cout << "  perf.tpot_ms: " << tpot_ms << std::endl;
+        std::cout << "  perf.throughput_toks_per_s: " << throughput << std::endl;
+    } else {
+        std::cout << "  perf.tpot_ms: N/A" << std::endl;
+        std::cout << "  perf.throughput_toks_per_s: N/A" << std::endl;
+    }
+
+    return 0;
+} catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return 1;
+}

--- a/src/cpp/src/modeling/samples/modeling_qwen3_asr.cpp
+++ b/src/cpp/src/modeling/samples/modeling_qwen3_asr.cpp
@@ -1011,6 +1011,20 @@ int main(int argc, char* argv[]) try {
         }
     }
 
+    ov::Tensor prompt_audio_embeds;
+    ov::Tensor prompt_audio_pos_mask;
+    ov::Tensor step_audio_embeds;
+    ov::Tensor step_audio_pos_mask;
+    if (!text_only) {
+        prompt_audio_embeds = make_audio_embeds_for_mask_positions(audio_embeds, base_audio_pos_flags);
+        prompt_audio_pos_mask = make_audio_pos_mask_from_flags(base_audio_pos_flags);
+
+        std::vector<char> no_audio_flags(1, 0);
+        ov::Tensor empty_audio_embeds(ov::element::f32, ov::Shape{1, 0, embeds_shape[2]});
+        step_audio_embeds = make_audio_embeds_for_mask_positions(empty_audio_embeds, no_audio_flags);
+        step_audio_pos_mask = make_audio_pos_mask_from_flags(no_audio_flags);
+    }
+
     std::vector<int64_t> generated_ids;
     generated_ids.reserve(static_cast<size_t>(max_new_tokens));
     int64_t prev_token_id = std::numeric_limits<int64_t>::min();
@@ -1040,98 +1054,128 @@ int main(int argc, char* argv[]) try {
     size_t infer_steps = 0;
     const auto asr_infer_start = std::chrono::steady_clock::now();
 
-    for (int32_t step = 0; step < max_new_tokens; ++step) {
-        // We run full-sequence decode each step; clear internal KV state to avoid
-        // stateful-cache shape accumulation across iterations.
-        text_request.reset_state();
-
-        const size_t seq_len = input_ids.size();
-        std::vector<char> step_audio_flags = base_audio_pos_flags;
-        if (seq_len > step_audio_flags.size()) {
-            step_audio_flags.resize(seq_len, 0);
+    auto should_stop_after_push = [&](int64_t pushed_token_id) -> bool {
+        if (pushed_token_id == prev_token_id) {
+            ++same_token_run;
+        } else {
+            prev_token_id = pushed_token_id;
+            same_token_run = 1;
+        }
+        if (same_token_run >= 32) {
+            return true;
         }
 
+        if (text_only) {
+            if (has_recent_ngram_loop(generated_ids, 8, 3) || has_recent_ngram_loop(generated_ids, 12, 3)) {
+                return true;
+            }
+            if (generated_ids.size() >= 64) {
+                if (pushed_token_id == dot_token_id || pushed_token_id == excl_token_id || pushed_token_id == qmark_token_id) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // ASR outputs can get stuck in repeated phrase loops; stop early when
+        // recent n-grams are repeated to keep transcript quality stable.
+        bool repeated_loop = has_recent_ngram_loop(generated_ids, 8, 3) ||
+                             has_recent_ngram_loop(generated_ids, 12, 3) ||
+                             has_recent_ngram_loop(generated_ids, 16, 2);
+        if (!repeated_loop) {
+            // Some ASR loops are shorter (e.g., ~10-15 tokens repeated twice).
+            for (size_t n = 6; n <= 16; ++n) {
+                if (has_recent_ngram_loop(generated_ids, n, 2)) {
+                    repeated_loop = true;
+                    break;
+                }
+            }
+        }
+        return repeated_loop;
+    };
+
+    text_request.reset_state();
+    text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kBeamIdx,
+                            make_i32({batch}, 0));
+
+    // Prefill: run full prompt once to initialize KV cache.
+    const size_t prompt_seq_len = input_ids.size();
+    text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kInputIds,
+                            make_i64_from_vector(input_ids));
+    text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kAttentionMask,
+                            make_i64({batch, prompt_seq_len}, 1));
+    text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kPositionIds,
+                            make_position_ids_3d(batch, prompt_seq_len));
+    if (!text_only) {
+        text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kAudioEmbeds,
+                                prompt_audio_embeds);
+        text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kAudioPosMask,
+                                prompt_audio_pos_mask);
+    }
+
+    const auto prefill_start = std::chrono::steady_clock::now();
+    text_request.infer();
+    const auto prefill_end = std::chrono::steady_clock::now();
+    ttft_ms = elapsed_ms(prefill_start, prefill_end);
+    infer_steps += 1;
+
+    size_t total_seq_len = prompt_seq_len;
+    auto process_logits_and_append = [&](const ov::Tensor& logits) -> bool {
+        logits_shape = logits.get_shape();
+        const int64_t next_token_id = argmax_last_token_id_excluding(logits, excluded_decode_ids);
+        const std::string next_token_text = tokenizer.decode({next_token_id}, {ov::genai::skip_special_tokens(false)});
+        if ((eos_token_id >= 0 && next_token_id == eos_token_id) || is_text_stop_token(next_token_text)) {
+            return true;
+        }
+        generated_ids.push_back(next_token_id);
+        return should_stop_after_push(next_token_id);
+    };
+
+    bool stop_generation = false;
+    {
+        ov::Tensor logits = text_request.get_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kLogits);
+        stop_generation = process_logits_and_append(logits);
+    }
+
+    ov::Tensor one_token_ids(ov::element::i64, ov::Shape{1, 1});
+    ov::Tensor one_token_pos_ids(ov::element::i64, ov::Shape{3, 1, 1});
+    int64_t* one_token_pos_ptr = one_token_pos_ids.data<int64_t>();
+
+    while (!stop_generation && generated_ids.size() < static_cast<size_t>(max_new_tokens)) {
+        const int64_t token_to_feed = generated_ids.back();
+        one_token_ids.data<int64_t>()[0] = token_to_feed;
+
+        total_seq_len += 1;
+        const int64_t pos = static_cast<int64_t>(total_seq_len - 1);
+        one_token_pos_ptr[0] = pos;
+        one_token_pos_ptr[1] = pos;
+        one_token_pos_ptr[2] = pos;
+
         text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kInputIds,
-                                make_i64_from_vector(input_ids));
+                                one_token_ids);
         text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kAttentionMask,
-                                make_i64({batch, seq_len}, 1));
+                                make_i64({batch, total_seq_len}, 1));
         text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kPositionIds,
-                                make_position_ids_3d(batch, seq_len));
-        text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kBeamIdx,
-                                make_i32({batch}, 0));
+                                one_token_pos_ids);
         if (!text_only) {
-            ov::Tensor step_audio_embeds = make_audio_embeds_for_mask_positions(audio_embeds, step_audio_flags);
             text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kAudioEmbeds,
                                     step_audio_embeds);
             text_request.set_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kAudioPosMask,
-                                    make_audio_pos_mask_from_flags(step_audio_flags));
+                                    step_audio_pos_mask);
         }
 
         const auto step_start = std::chrono::steady_clock::now();
         text_request.infer();
         const auto step_end = std::chrono::steady_clock::now();
-
         const double step_ms = elapsed_ms(step_start, step_end);
-        if (step == 0) {
-            ttft_ms = step_ms;
-        }
+        decode_ms += step_ms;
+        decode_tail_tokens += 1;
         infer_steps += 1;
 
         ov::Tensor logits = text_request.get_tensor(ov::genai::modeling::models::Qwen3ASRTextIO::kLogits);
-        logits_shape = logits.get_shape();
-        const int64_t next_token_id = argmax_last_token_id_excluding(logits, excluded_decode_ids);
-        const std::string next_token_text = tokenizer.decode({next_token_id}, {ov::genai::skip_special_tokens(false)});
-
-        if ((eos_token_id >= 0 && next_token_id == eos_token_id) || is_text_stop_token(next_token_text)) {
+        if (process_logits_and_append(logits)) {
+            stop_generation = true;
             break;
-        }
-
-        if (next_token_id == prev_token_id) {
-            ++same_token_run;
-        } else {
-            prev_token_id = next_token_id;
-            same_token_run = 1;
-        }
-        if (same_token_run >= 32) {
-            break;
-        }
-
-        generated_ids.push_back(next_token_id);
-        input_ids.push_back(next_token_id);
-
-        // Additional anti-degeneracy stop criteria for text-only path.
-        if (text_only) {
-            if (has_recent_ngram_loop(generated_ids, 8, 3) || has_recent_ngram_loop(generated_ids, 12, 3)) {
-                break;
-            }
-            if (generated_ids.size() >= 64) {
-                if (next_token_id == dot_token_id || next_token_id == excl_token_id || next_token_id == qmark_token_id) {
-                    break;
-                }
-            }
-        } else {
-            // ASR outputs can get stuck in repeated phrase loops; stop early when
-            // recent n-grams are repeated to keep transcript quality stable.
-            bool repeated_loop = has_recent_ngram_loop(generated_ids, 8, 3) ||
-                                 has_recent_ngram_loop(generated_ids, 12, 3) ||
-                                 has_recent_ngram_loop(generated_ids, 16, 2);
-            if (!repeated_loop) {
-                // Some ASR loops are shorter (e.g., ~10-15 tokens repeated twice).
-                for (size_t n = 6; n <= 16; ++n) {
-                    if (has_recent_ngram_loop(generated_ids, n, 2)) {
-                        repeated_loop = true;
-                        break;
-                    }
-                }
-            }
-            if (repeated_loop) {
-                break;
-            }
-        }
-
-        if (step > 0) {
-            decode_ms += step_ms;
-            decode_tail_tokens += 1;
         }
     }
     const auto asr_infer_end = std::chrono::steady_clock::now();

--- a/src/cpp/src/modeling/tests/qwen3_asr_modeling_test.cpp
+++ b/src/cpp/src/modeling/tests/qwen3_asr_modeling_test.cpp
@@ -1,0 +1,438 @@
+// Copyright (C) 2023-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fstream>
+#include <filesystem>
+
+#include <gtest/gtest.h>
+
+#include "loaders/model_builder.hpp"
+#include "loaders/model_config.hpp"
+#include "modeling/models/qwen3_asr/modeling_qwen3_asr.hpp"
+#include "modeling/tests/test_utils.hpp"
+
+namespace test_utils = ov::genai::modeling::tests;
+
+namespace {
+
+int64_t ref_feat_len(int64_t input_length) {
+  auto floor_div = [](int64_t a, int64_t b) -> int64_t {
+    int64_t q = a / b;
+    int64_t r = a % b;
+    if (r != 0 && ((r > 0) != (b > 0))) {
+      --q;
+    }
+    return q;
+  };
+    const int64_t input_lengths_leave = input_length % 100;
+  const int64_t feat_lengths = floor_div(input_lengths_leave - 1, 2) + 1;
+  const int64_t output_lengths =
+    (floor_div((floor_div(feat_lengths - 1, 2) + 1 - 1), 2) + 1 + floor_div(input_length, 100) * 13);
+    return output_lengths;
+}
+
+}  // namespace
+
+TEST(Qwen3ASRModeling, FeatureLengthFormulaBasicCases) {
+    using ov::genai::modeling::models::qwen3_asr_feat_extract_output_length;
+
+    EXPECT_EQ(qwen3_asr_feat_extract_output_length(1), 1);
+    EXPECT_EQ(qwen3_asr_feat_extract_output_length(10), 2);
+    EXPECT_EQ(qwen3_asr_feat_extract_output_length(100), 13);
+    EXPECT_EQ(qwen3_asr_feat_extract_output_length(101), 14);
+      EXPECT_EQ(qwen3_asr_feat_extract_output_length(256), 33);
+
+    for (int64_t n : {1LL, 2LL, 3LL, 9LL, 10LL, 20LL, 99LL, 100LL, 101LL, 199LL, 200LL, 256LL, 399LL, 400LL}) {
+        EXPECT_EQ(qwen3_asr_feat_extract_output_length(n), ref_feat_len(n));
+    }
+}
+
+TEST(Qwen3ASRModeling, ModelConfigParsesNestedThinkerTextConfig) {
+    namespace fs = std::filesystem;
+
+    const fs::path tmp = fs::temp_directory_path() / "ov_qwen3_asr_config_test.json";
+    {
+        std::ofstream out(tmp);
+        out << R"({
+  "model_type": "qwen3_asr",
+  "thinker_config": {
+    "text_config": {
+      "hidden_size": 4096,
+      "intermediate_size": 22016,
+      "num_hidden_layers": 32,
+      "num_attention_heads": 32,
+      "num_key_value_heads": 8,
+      "head_dim": 128,
+      "vocab_size": 151936,
+      "max_position_embeddings": 128000,
+      "rms_norm_eps": 1e-6,
+      "rope_theta": 5000000.0,
+      "hidden_act": "silu",
+      "attention_bias": false,
+      "tie_word_embeddings": false
+    }
+  }
+})";
+    }
+
+    auto cfg = ov::genai::loaders::ModelConfig::from_hf_json(tmp);
+
+    EXPECT_EQ(cfg.model_type, "qwen3_asr");
+    EXPECT_EQ(cfg.architecture, "qwen3_asr");
+    EXPECT_EQ(cfg.hidden_size, 4096);
+    EXPECT_EQ(cfg.intermediate_size, 22016);
+    EXPECT_EQ(cfg.num_hidden_layers, 32);
+    EXPECT_EQ(cfg.num_attention_heads, 32);
+    EXPECT_EQ(cfg.num_key_value_heads, 8);
+    EXPECT_EQ(cfg.head_dim, 128);
+    EXPECT_EQ(cfg.vocab_size, 151936);
+    EXPECT_EQ(cfg.max_position_embeddings, 128000);
+
+    std::error_code ec;
+    fs::remove(tmp, ec);
+}
+
+  TEST(Qwen3ASRModeling, ModelConfigParsesAudioEncoderConfig) {
+    namespace fs = std::filesystem;
+
+    const fs::path tmp = fs::temp_directory_path() / "ov_qwen3_asr_audio_config_test.json";
+    {
+      std::ofstream out(tmp);
+      out << R"({
+    "model_type": "qwen3_asr_audio_encoder",
+    "num_mel_bins": 128,
+    "encoder_layers": 32,
+    "encoder_attention_heads": 20,
+    "encoder_ffn_dim": 5120,
+    "d_model": 1280,
+    "max_source_positions": 1500,
+    "activation_function": "gelu"
+  })";
+    }
+
+    auto cfg = ov::genai::loaders::ModelConfig::from_hf_json(tmp);
+
+    EXPECT_EQ(cfg.model_type, "qwen3_asr_audio_encoder");
+    EXPECT_EQ(cfg.architecture, "qwen3_asr_audio_encoder");
+    EXPECT_EQ(cfg.hidden_size, 1280);
+    EXPECT_EQ(cfg.intermediate_size, 5120);
+    EXPECT_EQ(cfg.num_hidden_layers, 32);
+    EXPECT_EQ(cfg.num_attention_heads, 20);
+    EXPECT_EQ(cfg.max_position_embeddings, 1500);
+    EXPECT_EQ(cfg.hidden_act, "gelu");
+
+    std::error_code ec;
+    fs::remove(tmp, ec);
+  }
+
+  TEST(Qwen3ASRModeling, ModelBuilderRegistrationsExist) {
+    auto& builder = ov::genai::loaders::ModelBuilder::instance();
+
+    EXPECT_TRUE(builder.has_architecture("qwen3_asr"));
+    EXPECT_TRUE(builder.has_architecture("qwen3asr"));
+    EXPECT_TRUE(builder.has_architecture("qwen3_asr_text"));
+
+    EXPECT_TRUE(builder.has_architecture("qwen3_asr_audio_encoder"));
+    EXPECT_TRUE(builder.has_architecture("qwen3asraudioencoder"));
+  }
+
+  TEST(Qwen3ASRModeling, AudioEncoderModelBuildsWithDummyWeights) {
+    // Small config for fast graph construction.
+    ov::genai::modeling::models::Qwen3ASRAudioConfig cfg;
+    cfg.num_mel_bins = 8;
+    cfg.d_model = 4;
+    cfg.encoder_layers = 1;
+    cfg.encoder_attention_heads = 2;
+    cfg.encoder_ffn_dim = 8;
+    cfg.output_dim = 6;
+    cfg.max_source_positions = 16;
+    cfg.downsample_hidden_size = 2;
+    cfg.activation_function = "gelu";
+
+    // conv_out input dim formula in implementation:
+    // downsample_hidden_size * ((((num_mel_bins + 1) // 2 + 1) // 2 + 1) // 2)
+    const size_t conv_out_in = static_cast<size_t>(cfg.downsample_hidden_size) *
+                   static_cast<size_t>(((((cfg.num_mel_bins + 1) / 2 + 1) / 2 + 1) / 2));
+
+    test_utils::DummyWeightSource weights;
+    // Conv stem
+    weights.add("audio_tower.conv2d1.weight", test_utils::make_tensor(test_utils::make_seq(2 * 1 * 3 * 3, 0.01f, 0.001f), {2, 1, 3, 3}));
+    weights.add("audio_tower.conv2d1.bias", test_utils::make_tensor(test_utils::make_seq(2, 0.0f, 0.0f), {2}));
+    weights.add("audio_tower.conv2d2.weight", test_utils::make_tensor(test_utils::make_seq(2 * 2 * 3 * 3, 0.01f, 0.001f), {2, 2, 3, 3}));
+    weights.add("audio_tower.conv2d2.bias", test_utils::make_tensor(test_utils::make_seq(2, 0.0f, 0.0f), {2}));
+    weights.add("audio_tower.conv2d3.weight", test_utils::make_tensor(test_utils::make_seq(2 * 2 * 3 * 3, 0.01f, 0.001f), {2, 2, 3, 3}));
+    weights.add("audio_tower.conv2d3.bias", test_utils::make_tensor(test_utils::make_seq(2, 0.0f, 0.0f), {2}));
+    weights.add("audio_tower.conv_out.weight", test_utils::make_tensor(test_utils::make_seq(4 * conv_out_in, 0.01f, 0.001f), {4, conv_out_in}));
+
+    // Encoder layer[0]
+    weights.add("audio_tower.layers[0].self_attn.q_proj.weight", test_utils::make_tensor(test_utils::make_seq(4 * 4, 0.01f, 0.001f), {4, 4}));
+    weights.add("audio_tower.layers[0].self_attn.q_proj.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+    weights.add("audio_tower.layers[0].self_attn.k_proj.weight", test_utils::make_tensor(test_utils::make_seq(4 * 4, 0.01f, 0.001f), {4, 4}));
+    weights.add("audio_tower.layers[0].self_attn.k_proj.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+    weights.add("audio_tower.layers[0].self_attn.v_proj.weight", test_utils::make_tensor(test_utils::make_seq(4 * 4, 0.01f, 0.001f), {4, 4}));
+    weights.add("audio_tower.layers[0].self_attn.v_proj.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+    weights.add("audio_tower.layers[0].self_attn.out_proj.weight", test_utils::make_tensor(test_utils::make_seq(4 * 4, 0.01f, 0.001f), {4, 4}));
+    weights.add("audio_tower.layers[0].self_attn.out_proj.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+
+    weights.add("audio_tower.layers[0].self_attn_layer_norm.weight", test_utils::make_tensor(test_utils::make_seq(4, 1.0f, 0.0f), {4}));
+    weights.add("audio_tower.layers[0].self_attn_layer_norm.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+    weights.add("audio_tower.layers[0].final_layer_norm.weight", test_utils::make_tensor(test_utils::make_seq(4, 1.0f, 0.0f), {4}));
+    weights.add("audio_tower.layers[0].final_layer_norm.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+
+    weights.add("audio_tower.layers[0].fc1.weight", test_utils::make_tensor(test_utils::make_seq(8 * 4, 0.01f, 0.001f), {8, 4}));
+    weights.add("audio_tower.layers[0].fc1.bias", test_utils::make_tensor(test_utils::make_seq(8, 0.0f, 0.0f), {8}));
+    weights.add("audio_tower.layers[0].fc2.weight", test_utils::make_tensor(test_utils::make_seq(4 * 8, 0.01f, 0.001f), {4, 8}));
+    weights.add("audio_tower.layers[0].fc2.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+
+    // Output projection
+    weights.add("audio_tower.ln_post.weight", test_utils::make_tensor(test_utils::make_seq(4, 1.0f, 0.0f), {4}));
+    weights.add("audio_tower.ln_post.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+    weights.add("audio_tower.proj1.weight", test_utils::make_tensor(test_utils::make_seq(4 * 4, 0.01f, 0.001f), {4, 4}));
+    weights.add("audio_tower.proj1.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+    weights.add("audio_tower.proj2.weight", test_utils::make_tensor(test_utils::make_seq(6 * 4, 0.01f, 0.001f), {6, 4}));
+    weights.add("audio_tower.proj2.bias", test_utils::make_tensor(test_utils::make_seq(6, 0.0f, 0.0f), {6}));
+
+    test_utils::DummyWeightFinalizer finalizer;
+
+    std::shared_ptr<ov::Model> model;
+    EXPECT_NO_THROW(model = ov::genai::modeling::models::create_qwen3_asr_audio_encoder_model(cfg, weights, finalizer));
+    ASSERT_NE(model, nullptr);
+
+    EXPECT_EQ(model->inputs().size(), 2u);
+    EXPECT_EQ(model->outputs().size(), 2u);
+
+    EXPECT_TRUE(model->output(0).get_names().count("audio_embeds") > 0);
+    EXPECT_TRUE(model->output(1).get_names().count("audio_output_lengths") > 0);
+    EXPECT_EQ(model->output(0).get_partial_shape().rank().get_length(), 3);
+    EXPECT_EQ(model->output(1).get_partial_shape().rank().get_length(), 1);
+  }
+
+  TEST(Qwen3ASRModeling, TextModelBuildsWithThinkerPrefixedWeightsAndAudioInputs) {
+    // Tiny text config for build-time smoke test.
+    ov::genai::modeling::models::Qwen3ASRTextConfig cfg;
+    cfg.architecture = "qwen3_asr";
+    cfg.vocab_size = 8;
+    cfg.hidden_size = 4;
+    cfg.intermediate_size = 6;
+    cfg.num_hidden_layers = 1;
+    cfg.num_attention_heads = 2;
+    cfg.num_key_value_heads = 1;
+    cfg.head_dim = 2;
+    cfg.max_position_embeddings = 64;
+    cfg.rms_norm_eps = 1e-6f;
+    cfg.rope_theta = 10000.0f;
+    cfg.hidden_act = "silu";
+    cfg.attention_bias = true;
+    cfg.tie_word_embeddings = false;
+
+    const size_t vocab = static_cast<size_t>(cfg.vocab_size);
+    const size_t hidden = static_cast<size_t>(cfg.hidden_size);
+    const size_t intermediate = static_cast<size_t>(cfg.intermediate_size);
+    const size_t num_kv_heads = static_cast<size_t>(cfg.num_key_value_heads);
+    const size_t head_dim = static_cast<size_t>(cfg.head_dim);
+    const size_t kv_hidden = num_kv_heads * head_dim;
+
+    test_utils::DummyWeightSource weights;
+
+    // thinker.* names verify packed mapping in create_qwen3_asr_text_model().
+    weights.add("thinker.model.embed_tokens.weight",
+          test_utils::make_tensor(test_utils::make_seq(vocab * hidden, 0.01f, 0.001f), {vocab, hidden}));
+
+    weights.add("thinker.model.layers[0].input_layernorm.weight",
+          test_utils::make_tensor(test_utils::make_seq(hidden, 1.0f, 0.0f), {hidden}));
+    weights.add("thinker.model.layers[0].post_attention_layernorm.weight",
+          test_utils::make_tensor(test_utils::make_seq(hidden, 1.0f, 0.0f), {hidden}));
+
+    weights.add("thinker.model.layers[0].self_attn.q_proj.weight",
+          test_utils::make_tensor(test_utils::make_seq(hidden * hidden, 0.01f, 0.001f), {hidden, hidden}));
+    weights.add("thinker.model.layers[0].self_attn.k_proj.weight",
+          test_utils::make_tensor(test_utils::make_seq(kv_hidden * hidden, 0.01f, 0.001f), {kv_hidden, hidden}));
+    weights.add("thinker.model.layers[0].self_attn.v_proj.weight",
+          test_utils::make_tensor(test_utils::make_seq(kv_hidden * hidden, 0.01f, 0.001f), {kv_hidden, hidden}));
+    weights.add("thinker.model.layers[0].self_attn.o_proj.weight",
+          test_utils::make_tensor(test_utils::make_seq(hidden * hidden, 0.01f, 0.001f), {hidden, hidden}));
+
+    weights.add("thinker.model.layers[0].self_attn.q_proj.bias",
+          test_utils::make_tensor(test_utils::make_seq(hidden, 0.0f, 0.0f), {hidden}));
+    weights.add("thinker.model.layers[0].self_attn.k_proj.bias",
+          test_utils::make_tensor(test_utils::make_seq(kv_hidden, 0.0f, 0.0f), {kv_hidden}));
+    weights.add("thinker.model.layers[0].self_attn.v_proj.bias",
+          test_utils::make_tensor(test_utils::make_seq(kv_hidden, 0.0f, 0.0f), {kv_hidden}));
+    weights.add("thinker.model.layers[0].self_attn.o_proj.bias",
+          test_utils::make_tensor(test_utils::make_seq(hidden, 0.0f, 0.0f), {hidden}));
+
+    weights.add("thinker.model.layers[0].self_attn.q_norm.weight",
+          test_utils::make_tensor(test_utils::make_seq(head_dim, 1.0f, 0.0f), {head_dim}));
+    weights.add("thinker.model.layers[0].self_attn.k_norm.weight",
+          test_utils::make_tensor(test_utils::make_seq(head_dim, 1.0f, 0.0f), {head_dim}));
+
+    weights.add("thinker.model.layers[0].mlp.gate_proj.weight",
+          test_utils::make_tensor(test_utils::make_seq(intermediate * hidden, 0.01f, 0.001f), {intermediate, hidden}));
+    weights.add("thinker.model.layers[0].mlp.up_proj.weight",
+          test_utils::make_tensor(test_utils::make_seq(intermediate * hidden, 0.01f, 0.001f), {intermediate, hidden}));
+    weights.add("thinker.model.layers[0].mlp.down_proj.weight",
+          test_utils::make_tensor(test_utils::make_seq(hidden * intermediate, 0.01f, 0.001f), {hidden, intermediate}));
+
+    weights.add("thinker.model.norm.weight",
+          test_utils::make_tensor(test_utils::make_seq(hidden, 1.0f, 0.0f), {hidden}));
+    weights.add("thinker.lm_head.weight",
+          test_utils::make_tensor(test_utils::make_seq(vocab * hidden, 0.01f, 0.001f), {vocab, hidden}));
+
+    test_utils::DummyWeightFinalizer finalizer;
+
+    std::shared_ptr<ov::Model> model;
+    EXPECT_NO_THROW(model = ov::genai::modeling::models::create_qwen3_asr_text_model(
+      cfg,
+      weights,
+      finalizer,
+      false,
+      true));
+    ASSERT_NE(model, nullptr);
+
+    // input_ids + attention_mask + position_ids + beam_idx + audio_embeds + audio_pos_mask
+    EXPECT_EQ(model->inputs().size(), 6u);
+    EXPECT_EQ(model->outputs().size(), 1u);
+
+    EXPECT_TRUE(model->output(0).get_names().count("logits") > 0);
+    EXPECT_EQ(model->output(0).get_partial_shape().rank().get_length(), 3);
+  }
+
+TEST(Qwen3ASRModeling, AudioAndTextModelInterfacesAreCompatible) {
+      // Build a tiny audio encoder.
+      ov::genai::modeling::models::Qwen3ASRAudioConfig audio_cfg;
+      audio_cfg.architecture = "qwen3_asr_audio_encoder";
+      audio_cfg.num_mel_bins = 8;
+      audio_cfg.d_model = 4;
+      audio_cfg.encoder_layers = 1;
+      audio_cfg.encoder_attention_heads = 2;
+      audio_cfg.encoder_ffn_dim = 8;
+      audio_cfg.output_dim = 4;  // Must match text hidden_size for interface check.
+      audio_cfg.max_source_positions = 16;
+      audio_cfg.downsample_hidden_size = 2;
+      audio_cfg.activation_function = "gelu";
+
+      const size_t conv_out_in = static_cast<size_t>(audio_cfg.downsample_hidden_size) *
+                                 static_cast<size_t>(((((audio_cfg.num_mel_bins + 1) / 2 + 1) / 2 + 1) / 2));
+
+      test_utils::DummyWeightSource audio_weights;
+      audio_weights.add("audio_tower.conv2d1.weight", test_utils::make_tensor(test_utils::make_seq(2 * 1 * 3 * 3, 0.01f, 0.001f), {2, 1, 3, 3}));
+      audio_weights.add("audio_tower.conv2d1.bias", test_utils::make_tensor(test_utils::make_seq(2, 0.0f, 0.0f), {2}));
+      audio_weights.add("audio_tower.conv2d2.weight", test_utils::make_tensor(test_utils::make_seq(2 * 2 * 3 * 3, 0.01f, 0.001f), {2, 2, 3, 3}));
+      audio_weights.add("audio_tower.conv2d2.bias", test_utils::make_tensor(test_utils::make_seq(2, 0.0f, 0.0f), {2}));
+      audio_weights.add("audio_tower.conv2d3.weight", test_utils::make_tensor(test_utils::make_seq(2 * 2 * 3 * 3, 0.01f, 0.001f), {2, 2, 3, 3}));
+      audio_weights.add("audio_tower.conv2d3.bias", test_utils::make_tensor(test_utils::make_seq(2, 0.0f, 0.0f), {2}));
+      audio_weights.add("audio_tower.conv_out.weight", test_utils::make_tensor(test_utils::make_seq(4 * conv_out_in, 0.01f, 0.001f), {4, conv_out_in}));
+
+      audio_weights.add("audio_tower.layers[0].self_attn.q_proj.weight", test_utils::make_tensor(test_utils::make_seq(4 * 4, 0.01f, 0.001f), {4, 4}));
+      audio_weights.add("audio_tower.layers[0].self_attn.q_proj.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+      audio_weights.add("audio_tower.layers[0].self_attn.k_proj.weight", test_utils::make_tensor(test_utils::make_seq(4 * 4, 0.01f, 0.001f), {4, 4}));
+      audio_weights.add("audio_tower.layers[0].self_attn.k_proj.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+      audio_weights.add("audio_tower.layers[0].self_attn.v_proj.weight", test_utils::make_tensor(test_utils::make_seq(4 * 4, 0.01f, 0.001f), {4, 4}));
+      audio_weights.add("audio_tower.layers[0].self_attn.v_proj.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+      audio_weights.add("audio_tower.layers[0].self_attn.out_proj.weight", test_utils::make_tensor(test_utils::make_seq(4 * 4, 0.01f, 0.001f), {4, 4}));
+      audio_weights.add("audio_tower.layers[0].self_attn.out_proj.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+
+      audio_weights.add("audio_tower.layers[0].self_attn_layer_norm.weight", test_utils::make_tensor(test_utils::make_seq(4, 1.0f, 0.0f), {4}));
+      audio_weights.add("audio_tower.layers[0].self_attn_layer_norm.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+      audio_weights.add("audio_tower.layers[0].final_layer_norm.weight", test_utils::make_tensor(test_utils::make_seq(4, 1.0f, 0.0f), {4}));
+      audio_weights.add("audio_tower.layers[0].final_layer_norm.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+
+      audio_weights.add("audio_tower.layers[0].fc1.weight", test_utils::make_tensor(test_utils::make_seq(8 * 4, 0.01f, 0.001f), {8, 4}));
+      audio_weights.add("audio_tower.layers[0].fc1.bias", test_utils::make_tensor(test_utils::make_seq(8, 0.0f, 0.0f), {8}));
+      audio_weights.add("audio_tower.layers[0].fc2.weight", test_utils::make_tensor(test_utils::make_seq(4 * 8, 0.01f, 0.001f), {4, 8}));
+      audio_weights.add("audio_tower.layers[0].fc2.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+
+      audio_weights.add("audio_tower.ln_post.weight", test_utils::make_tensor(test_utils::make_seq(4, 1.0f, 0.0f), {4}));
+      audio_weights.add("audio_tower.ln_post.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+      audio_weights.add("audio_tower.proj1.weight", test_utils::make_tensor(test_utils::make_seq(4 * 4, 0.01f, 0.001f), {4, 4}));
+      audio_weights.add("audio_tower.proj1.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+      audio_weights.add("audio_tower.proj2.weight", test_utils::make_tensor(test_utils::make_seq(4 * 4, 0.01f, 0.001f), {4, 4}));
+      audio_weights.add("audio_tower.proj2.bias", test_utils::make_tensor(test_utils::make_seq(4, 0.0f, 0.0f), {4}));
+
+      test_utils::DummyWeightFinalizer audio_finalizer;
+      auto audio_model = ov::genai::modeling::models::create_qwen3_asr_audio_encoder_model(audio_cfg, audio_weights, audio_finalizer);
+      ASSERT_NE(audio_model, nullptr);
+
+      // Build a tiny text model expecting audio embeds with hidden_size=4.
+      ov::genai::modeling::models::Qwen3ASRTextConfig text_cfg;
+      text_cfg.architecture = "qwen3_asr";
+      text_cfg.vocab_size = 8;
+      text_cfg.hidden_size = 4;
+      text_cfg.intermediate_size = 6;
+      text_cfg.num_hidden_layers = 1;
+      text_cfg.num_attention_heads = 2;
+      text_cfg.num_key_value_heads = 1;
+      text_cfg.head_dim = 2;
+      text_cfg.max_position_embeddings = 64;
+      text_cfg.rms_norm_eps = 1e-6f;
+      text_cfg.rope_theta = 10000.0f;
+      text_cfg.hidden_act = "silu";
+      text_cfg.attention_bias = true;
+      text_cfg.tie_word_embeddings = false;
+
+      const size_t vocab = static_cast<size_t>(text_cfg.vocab_size);
+      const size_t hidden = static_cast<size_t>(text_cfg.hidden_size);
+      const size_t intermediate = static_cast<size_t>(text_cfg.intermediate_size);
+      const size_t kv_hidden = static_cast<size_t>(text_cfg.num_key_value_heads * text_cfg.head_dim);
+
+      test_utils::DummyWeightSource text_weights;
+      text_weights.add("thinker.model.embed_tokens.weight",
+                               test_utils::make_tensor(test_utils::make_seq(vocab * hidden, 0.01f, 0.001f), {vocab, hidden}));
+      text_weights.add("thinker.model.layers[0].input_layernorm.weight",
+                               test_utils::make_tensor(test_utils::make_seq(hidden, 1.0f, 0.0f), {hidden}));
+      text_weights.add("thinker.model.layers[0].post_attention_layernorm.weight",
+                               test_utils::make_tensor(test_utils::make_seq(hidden, 1.0f, 0.0f), {hidden}));
+      text_weights.add("thinker.model.layers[0].self_attn.q_proj.weight",
+                               test_utils::make_tensor(test_utils::make_seq(hidden * hidden, 0.01f, 0.001f), {hidden, hidden}));
+      text_weights.add("thinker.model.layers[0].self_attn.k_proj.weight",
+                               test_utils::make_tensor(test_utils::make_seq(kv_hidden * hidden, 0.01f, 0.001f), {kv_hidden, hidden}));
+      text_weights.add("thinker.model.layers[0].self_attn.v_proj.weight",
+                               test_utils::make_tensor(test_utils::make_seq(kv_hidden * hidden, 0.01f, 0.001f), {kv_hidden, hidden}));
+      text_weights.add("thinker.model.layers[0].self_attn.o_proj.weight",
+                               test_utils::make_tensor(test_utils::make_seq(hidden * hidden, 0.01f, 0.001f), {hidden, hidden}));
+      text_weights.add("thinker.model.layers[0].self_attn.q_proj.bias", test_utils::make_tensor(test_utils::make_seq(hidden, 0.0f, 0.0f), {hidden}));
+      text_weights.add("thinker.model.layers[0].self_attn.k_proj.bias", test_utils::make_tensor(test_utils::make_seq(kv_hidden, 0.0f, 0.0f), {kv_hidden}));
+      text_weights.add("thinker.model.layers[0].self_attn.v_proj.bias", test_utils::make_tensor(test_utils::make_seq(kv_hidden, 0.0f, 0.0f), {kv_hidden}));
+      text_weights.add("thinker.model.layers[0].self_attn.o_proj.bias", test_utils::make_tensor(test_utils::make_seq(hidden, 0.0f, 0.0f), {hidden}));
+      text_weights.add("thinker.model.layers[0].self_attn.q_norm.weight", test_utils::make_tensor(test_utils::make_seq(static_cast<size_t>(text_cfg.head_dim), 1.0f, 0.0f), {static_cast<size_t>(text_cfg.head_dim)}));
+      text_weights.add("thinker.model.layers[0].self_attn.k_norm.weight", test_utils::make_tensor(test_utils::make_seq(static_cast<size_t>(text_cfg.head_dim), 1.0f, 0.0f), {static_cast<size_t>(text_cfg.head_dim)}));
+      text_weights.add("thinker.model.layers[0].mlp.gate_proj.weight",
+                               test_utils::make_tensor(test_utils::make_seq(intermediate * hidden, 0.01f, 0.001f), {intermediate, hidden}));
+      text_weights.add("thinker.model.layers[0].mlp.up_proj.weight",
+                               test_utils::make_tensor(test_utils::make_seq(intermediate * hidden, 0.01f, 0.001f), {intermediate, hidden}));
+      text_weights.add("thinker.model.layers[0].mlp.down_proj.weight",
+                               test_utils::make_tensor(test_utils::make_seq(hidden * intermediate, 0.01f, 0.001f), {hidden, intermediate}));
+      text_weights.add("thinker.model.norm.weight", test_utils::make_tensor(test_utils::make_seq(hidden, 1.0f, 0.0f), {hidden}));
+      text_weights.add("thinker.lm_head.weight",
+                               test_utils::make_tensor(test_utils::make_seq(vocab * hidden, 0.01f, 0.001f), {vocab, hidden}));
+
+      test_utils::DummyWeightFinalizer text_finalizer;
+      auto text_model = ov::genai::modeling::models::create_qwen3_asr_text_model(text_cfg, text_weights, text_finalizer, false, true);
+      ASSERT_NE(text_model, nullptr);
+
+      auto get_input_shape_by_name = [](const std::shared_ptr<ov::Model>& m,
+                                                        const std::string& tensor_name) -> ov::PartialShape {
+            for (const auto& input : m->inputs()) {
+                  if (input.get_names().count(tensor_name) > 0) {
+                        return input.get_partial_shape();
+                  }
+            }
+            return {};
+      };
+
+      const ov::PartialShape audio_embeds_out = audio_model->output("audio_embeds").get_partial_shape();
+      const ov::PartialShape audio_embeds_in = get_input_shape_by_name(text_model, "audio_embeds");
+      const ov::PartialShape audio_pos_mask_in = get_input_shape_by_name(text_model, "audio_pos_mask");
+
+      ASSERT_TRUE(audio_embeds_out.rank().is_static());
+      ASSERT_TRUE(audio_embeds_in.rank().is_static());
+      ASSERT_TRUE(audio_pos_mask_in.rank().is_static());
+
+      EXPECT_EQ(audio_embeds_out.rank().get_length(), 3);
+      EXPECT_EQ(audio_embeds_in.rank().get_length(), 3);
+      EXPECT_EQ(audio_pos_mask_in.rank().get_length(), 2);
+
+      ASSERT_TRUE(audio_embeds_out[2].is_static());
+      ASSERT_TRUE(audio_embeds_in[2].is_static());
+      EXPECT_EQ(audio_embeds_out[2].get_length(), audio_embeds_in[2].get_length());
+}


### PR DESCRIPTION
1. add qwen3_asr and qwen3_asr_audio_encoder architecture parsing in ModelConfig, including nested thinker_config
2. introduce new Qwen3-ASR model implementation (modeling/models/qwen3_asr/*) for text + audio encoder graph building and builder registration
3. add comprehensive Qwen3-ASR unit tests covering config parsing, builder registration, feature-length formula, and text/audio interface compatibility
4. add modeling_qwen3_asr sample target and executable
5. implement WAV preprocessing in sample with mono/stereo decode, dynamic resampling to extractor sample rate, and runtime sample-rate reporting
6. improve sample generation behavior with anti-loop stopping, duplicate-tail trimming, and safer language-prefix handling
7. emit parser-friendly performance keys (Prompt token size, Output token size, Generate time, TTFT, TPOT, Throughput) alongside detailed perf stats

