### PR TITLE
tests(modeling): align MoE tests/reference with [B,S,H] hidden layout

### DIFF
--- a/src/cpp/src/modeling/tests/ops_test.cpp
+++ b/src/cpp/src/modeling/tests/ops_test.cpp
@@ -308,10 +308,9 @@ TEST(Ops, Moe3GemmFusedCompressed) {
     static_assert(hidden_size % group_size == 0, "hidden_size must be divisible by group_size");
     static_assert(inter_size % group_size == 0, "inter_size must be divisible by group_size");
 
-    const size_t tokens = batch * seq_len;
-    auto hidden_param = ctx.parameter("hidden", ov::element::f32, ov::Shape{tokens, hidden_size});
+    auto hidden_param = ctx.parameter("hidden", ov::element::f32, ov::Shape{batch, seq_len, hidden_size});
 
-    auto hidden_states = test_utils::random_f32(tokens * hidden_size, -0.5f, 0.5f, 11);
+    auto hidden_states = test_utils::random_f32(batch * seq_len * hidden_size, -0.5f, 0.5f, 11);
     auto gate_inp = test_utils::random_f32(num_experts * hidden_size, -0.5f, 0.5f, 23);
 
     auto gate_w_f32 = test_utils::random_f32(num_experts * inter_size * hidden_size, -0.5f, 0.5f, 31);
@@ -365,7 +364,7 @@ TEST(Ops, Moe3GemmFusedCompressed) {
     auto compiled = core.compile_model(model, "GPU");
     auto request = compiled.create_infer_request();
 
-    auto hidden_tensor = test_utils::make_tensor(hidden_states, {tokens, hidden_size});
+    auto hidden_tensor = test_utils::make_tensor(hidden_states, {batch, seq_len, hidden_size});
     request.set_input_tensor(0, hidden_tensor);
     request.infer();
 
@@ -389,9 +388,9 @@ TEST(Ops, Moe3GemmFusedCompressedwithInt4RouterWeights) {
     ov::genai::modeling::BuilderContext ctx;
 
     constexpr size_t batch = 1;
-    constexpr size_t seq_len = 16;
-    constexpr size_t hidden_size = 1024;
-    constexpr size_t inter_size = 2048;
+    constexpr size_t seq_len = 8;
+    constexpr size_t hidden_size = 512;
+    constexpr size_t inter_size = 1024;
     constexpr size_t num_experts = 8;
     constexpr size_t top_k = 4;
     constexpr size_t group_size = 128;
@@ -399,10 +398,9 @@ TEST(Ops, Moe3GemmFusedCompressedwithInt4RouterWeights) {
     static_assert(hidden_size % group_size == 0, "hidden_size must be divisible by group_size");
     static_assert(inter_size % group_size == 0, "inter_size must be divisible by group_size");
 
-    const size_t tokens = batch * seq_len;
-    auto hidden_param = ctx.parameter("hidden", ov::element::f32, ov::Shape{tokens, hidden_size});
+    auto hidden_param = ctx.parameter("hidden", ov::element::f32, ov::Shape{batch, seq_len, hidden_size});
 
-    auto hidden_states = test_utils::random_f32(tokens * hidden_size, -0.5f, 0.5f, 11);
+    auto hidden_states = test_utils::random_f32(batch * seq_len * hidden_size, -0.5f, 0.5f, 11);
     auto gate_inp = test_utils::random_f32(num_experts * hidden_size, -0.5f, 0.5f, 23);
     
     auto gate_w_f32 = test_utils::random_f32(num_experts * inter_size * hidden_size, -0.5f, 0.5f, 31);
@@ -459,7 +457,7 @@ TEST(Ops, Moe3GemmFusedCompressedwithInt4RouterWeights) {
 
     ov::serialize(compiled.get_runtime_model(), "Moe3GemmFusedCompressed_compiled.xml");
 
-    auto hidden_tensor = test_utils::make_tensor(hidden_states, {tokens, hidden_size});
+    auto hidden_tensor = test_utils::make_tensor(hidden_states, {batch, seq_len, hidden_size});
     request.set_input_tensor(0, hidden_tensor);
     request.infer();
     

--- a/src/cpp/src/modeling/tests/test_utils.cpp
+++ b/src/cpp/src/modeling/tests/test_utils.cpp
@@ -590,49 +590,62 @@ std::vector<float> moe_ref(const std::vector<float>& hidden_states,
     std::vector<float> topk_w;
     std::vector<float> logits(num_experts, 0.0f);
 
-    for (size_t t = 0; t < tokens; ++t) {
-        const float* x = &hidden_states[t * hidden_size];
-        for (size_t e = 0; e < num_experts; ++e) {
-            float acc = 0.0f;
-            const size_t base = e * hidden_size;
-            for (size_t h = 0; h < hidden_size; ++h) {
-                acc += x[h] * gate_inp[base + h];
-            }
-            logits[e] = acc;
-        }
-        topk_softmax(logits.data(), num_experts, top_k, topk_idx, topk_w);
+    // hidden_states is interpreted as contiguous [B, S, H], which is equivalent
+    // to flattened [T, H] with T = B * S.
+    auto hidden_ptr = [&](size_t b, size_t s) -> const float* {
+        const size_t t = b * seq_len + s;
+        return &hidden_states[t * hidden_size];
+    };
+    auto out_ptr = [&](size_t b, size_t s) -> float* {
+        const size_t t = b * seq_len + s;
+        return &output[t * hidden_size];
+    };
 
-        for (size_t k = 0; k < top_k; ++k) {
-            const size_t e = topk_idx[k];
-            const float w = topk_w[k];
-
-            std::vector<float> gate(inter_size, 0.0f);
-            std::vector<float> up(inter_size, 0.0f);
-            for (size_t i = 0; i < inter_size; ++i) {
-                float acc_g = 0.0f;
-                float acc_u = 0.0f;
-                const size_t base = (e * inter_size + i) * hidden_size;
-                for (size_t h = 0; h < hidden_size; ++h) {
-                    acc_g += x[h] * gate_w[base + h];
-                    acc_u += x[h] * up_w[base + h];
-                }
-                gate[i] = swish(acc_g);
-                up[i] = acc_u;
-            }
-
-            std::vector<float> hidden(inter_size, 0.0f);
-            for (size_t i = 0; i < inter_size; ++i) {
-                hidden[i] = gate[i] * up[i];
-            }
-
-            float* out = &output[t * hidden_size];
-            for (size_t h = 0; h < hidden_size; ++h) {
+    for (size_t b = 0; b < batch; ++b) {
+        for (size_t s = 0; s < seq_len; ++s) {
+            const float* x = hidden_ptr(b, s);
+            for (size_t e = 0; e < num_experts; ++e) {
                 float acc = 0.0f;
-                const size_t base = (e * hidden_size + h) * inter_size;
-                for (size_t i = 0; i < inter_size; ++i) {
-                    acc += hidden[i] * down_w[base + i];
+                const size_t base = e * hidden_size;
+                for (size_t h = 0; h < hidden_size; ++h) {
+                    acc += x[h] * gate_inp[base + h];
                 }
-                out[h] += w * acc;
+                logits[e] = acc;
+            }
+            topk_softmax(logits.data(), num_experts, top_k, topk_idx, topk_w);
+
+            for (size_t k = 0; k < top_k; ++k) {
+                const size_t e = topk_idx[k];
+                const float w = topk_w[k];
+
+                std::vector<float> gate(inter_size, 0.0f);
+                std::vector<float> up(inter_size, 0.0f);
+                for (size_t i = 0; i < inter_size; ++i) {
+                    float acc_g = 0.0f;
+                    float acc_u = 0.0f;
+                    const size_t base = (e * inter_size + i) * hidden_size;
+                    for (size_t h = 0; h < hidden_size; ++h) {
+                        acc_g += x[h] * gate_w[base + h];
+                        acc_u += x[h] * up_w[base + h];
+                    }
+                    gate[i] = swish(acc_g);
+                    up[i] = acc_u;
+                }
+
+                std::vector<float> hidden(inter_size, 0.0f);
+                for (size_t i = 0; i < inter_size; ++i) {
+                    hidden[i] = gate[i] * up[i];
+                }
+
+                float* out = out_ptr(b, s);
+                for (size_t h = 0; h < hidden_size; ++h) {
+                    float acc = 0.0f;
+                    const size_t base = (e * hidden_size + h) * inter_size;
+                    for (size_t i = 0; i < inter_size; ++i) {
+                        acc += hidden[i] * down_w[base + i];
+                    }
+                    out[h] += w * acc;
+                }
             }
         }
     }


### PR DESCRIPTION
- update Moe3GemmFusedCompressed tests to use hidden tensors shaped [batch, seq_len, hidden_size] instead of flattened [tokens, hidden_size]
- adjust random input sizing accordingly in both MoE test cases
- reduce Int4-router MoE test dimensions (seq_len/hidden/intermediate) for more stable execution
- refactor moe_ref token iteration to explicit (batch, seq) indexing while preserving math behavior
- add helper indexing lambdas/comments clarifying [B,S,H] contiguous interpretation
 
