### PR TITLE
Add 'youtu' model_type alias to fix Youtu-LLM-2B dispatch

### DIFF
--- a/src/cpp/src/safetensors_utils/safetensors_modeling.cpp
+++ b/src/cpp/src/safetensors_utils/safetensors_modeling.cpp
@@ -634,7 +634,7 @@ std::shared_ptr<ov::Model> create_model_with_modeling_api(
         cfg.mlp_bias = has_key("model.layers[0].mlp.gate_proj.bias");
         cfg.tie_word_embeddings = !has_key("lm_head.weight");
         ov_model = ov::genai::modeling::models::create_smollm3_model(cfg, source, finalizer);
-    } else if (hf_config.model_type == "youtu_llm") {
+    } else if (hf_config.model_type == "youtu" || hf_config.model_type == "youtu_llm") {
         ov::genai::modeling::models::YoutuConfig cfg;
         cfg.architecture = hf_config.model_type;
         cfg.hidden_size = hf_config.hidden_size;
@@ -986,10 +986,11 @@ std::shared_ptr<ov::Model> create_from_safetensors(
     const std::string& model_type = config.model_type;
 
     // Check if new modeling API should be used
-    const bool force_modeling_api = (model_type == "qwen3_next" || model_type == "qwen3_5_moe" || model_type == "qwen3_5");
+    const bool force_modeling_api = (model_type == "qwen3_next" || model_type == "qwen3_5_moe" || model_type == "qwen3_5"
+                                  || model_type == "youtu" || model_type == "youtu_llm");
     if (((model_type == "qwen3" || model_type == "qwen3_moe" || model_type == "qwen3_next" || 
           model_type == "qwen3_5_moe" || model_type == "qwen3_5" ||
-          model_type == "smollm3" || model_type == "youtu_llm") &&
+          model_type == "smollm3" || model_type == "youtu_llm" || model_type == "youtu") &&
          (use_modeling_api() || force_modeling_api))) {
         std::cout << "[Safetensors] Using new modeling API" << std::endl;
         model = create_model_with_modeling_api(config, st_data, final_quant_config, model_dir);


### PR DESCRIPTION
The model's config.json uses model_type='youtu' but the dispatch code only recognized 'youtu_llm', causing an 'Unsupported model architecture' error. Two changes:

1. Add 'youtu' to the create_model_with_modeling_api() condition alongside 'youtu_llm'.
2. Add both 'youtu' and 'youtu_llm' to force_modeling_api so the model routes through the modeling API without requiring OV_GENAI_USE_MODELING_API=1 (the youtu architecture has no legacy building_blocks path).

<!-- Keep your pull requests (PRs) as atomic as possible. That increases the likelihood that an individual PR won't be stuck because of adjacent problems, merge conflicts, or code review.
Your merged PR is going to appear in the automatically generated release notes on GitHub. So the clearer the title the better. -->
## Description
<!-- Please include a summary of the change. Also include relevant motivation and context. -->

<!-- Jira ticket number (e.g., 123). Delete if there's no ticket. -->
CVS-###

<!-- Remove if not applicable -->
Fixes #(issue)

## Checklist:
- [ ] Tests have been updated or added to cover the new code. <!-- If the change isn't maintenance related, update the tests at https://github.com/openvinotoolkit/openvino.genai/tree/master/tests or explain in the description why the tests don't need an update. -->
- [ ] This patch fully addresses the ticket. <!--- If follow-up pull requests are needed, specify in description. -->
- [ ] I have made corresponding changes to the documentation. <!-- Run github.com/\<username>/openvino.genai/actions/workflows/deploy_gh_pages.yml on your fork with your branch as a parameter to deploy a test version with the updated content. Replace this comment with the link to the built docs. -->
